### PR TITLE
[Feat/marker] Map API 활용한 커스텀 마커 띄우기 + 폴리곤 fetch 중복요청 수정

### DIFF
--- a/client/src/components/Map/index.tsx
+++ b/client/src/components/Map/index.tsx
@@ -2,11 +2,17 @@ import MapWrapper from '@components/Map/index.style';
 import {
   getCurrentLocation,
   requestCoord,
-  coordToAddress,
   coordToRegionCode,
   drawPolygon,
   deletePolygon,
 } from '@controllers/mapController';
+
+import {
+  requestMarkerInfo,
+  createMarkers,
+  displayMarkers,
+  hideMarkers,
+} from '@controllers/markerController';
 
 import React, { useRef, useEffect, useState } from 'react';
 
@@ -20,6 +26,7 @@ const Map: React.FC = () => {
     longitude: 126.570667,
   });
   const polygonInstances = useRef<Array<kakao.maps.Polygon> | null>(null);
+  const [markers, setMarkers] = useState(Array<kakao.maps.CustomOverlay>());
   const [scale, setScale] = useState(DEFAULT_SCALE);
 
   useEffect(() => {
@@ -95,6 +102,28 @@ const Map: React.FC = () => {
       }
     };
   }, [map, scale, latitude, longitude]);
+
+  useEffect(() => {
+    (async () => {
+      const markerInfos = await requestMarkerInfo(scale, [
+        '서울특별시',
+        '용산구',
+      ]);
+      const markers = createMarkers(markerInfos);
+      setMarkers(markers);
+    })();
+  }, [scale]);
+
+  useEffect(() => {
+    if (!map) return;
+
+    displayMarkers(markers, map);
+    return () => {
+      console.log(markers);
+      hideMarkers(markers);
+    };
+  }, [map, markers]);
+
   return <MapWrapper ref={mapWrapper} />;
 };
 

--- a/client/src/components/Map/index.tsx
+++ b/client/src/components/Map/index.tsx
@@ -3,31 +3,39 @@ import {
   getCurrentLocation,
   requestCoord,
   coordToRegionCode,
-  drawPolygon,
-  deletePolygon,
+  isRangeEqual,
+  createPolygons,
+  displayPolygons,
+  deletePolygons,
 } from '@controllers/mapController';
 
 import {
   requestMarkerInfo,
   createMarkers,
   displayMarkers,
-  hideMarkers,
+  deleteMarkers,
 } from '@controllers/markerController';
 
 import React, { useRef, useEffect, useState } from 'react';
 
-const DEFAULT_SCALE = 9;
+const DEFAULT_POSITION = {
+  latitude: 37.541,
+  longitude: 126.986,
+  scale: 9,
+};
 
 const Map: React.FC = () => {
   const mapWrapper = useRef<HTMLDivElement | null>(null);
   const [map, setMap] = useState<kakao.maps.Map | null>(null);
-  const [{ latitude, longitude }, setLatlng] = useState({
-    latitude: 33.450701,
-    longitude: 126.570667,
+
+  const [position, setPosition] = useState(DEFAULT_POSITION);
+  const [range, setRange] = useState({
+    region: Array<string>(),
+    scale: DEFAULT_POSITION.scale,
   });
-  const polygonInstances = useRef<Array<kakao.maps.Polygon> | null>(null);
+
   const [markers, setMarkers] = useState(Array<kakao.maps.CustomOverlay>());
-  const [scale, setScale] = useState(DEFAULT_SCALE);
+  const [polygons, setPolygons] = useState(Array<kakao.maps.Polygon>());
 
   useEffect(() => {
     if (!mapWrapper.current) {
@@ -35,9 +43,10 @@ const Map: React.FC = () => {
     }
 
     const wrapper = mapWrapper.current;
+    const { latitude, longitude, scale } = DEFAULT_POSITION;
     const options = {
-      center: new kakao.maps.LatLng(33.450701, 126.570667),
-      level: DEFAULT_SCALE,
+      center: new kakao.maps.LatLng(latitude, longitude),
+      level: scale,
     };
 
     const kakaoMap = new kakao.maps.Map(wrapper, options);
@@ -45,83 +54,78 @@ const Map: React.FC = () => {
 
     const onCurrentLocation = ([lat, lng]: [number, number]) => {
       kakaoMap.setCenter(new kakao.maps.LatLng(lat, lng));
-      setLatlng({ latitude: lat, longitude: lng });
+      setPosition((prevPos) => {
+        return { ...prevPos, latitude: lat, longitude: lng };
+      });
     };
-
     getCurrentLocation(onCurrentLocation);
 
-    const changeCenter = async () => {
+    const updatePosition = () => {
       const latlng = kakaoMap.getCenter();
       const latitude = latlng.getLat();
       const longitude = latlng.getLng();
-      setLatlng({ latitude, longitude });
-    };
-
-    const changeScale = async () => {
-      const latlng = kakaoMap.getCenter();
       const scale = kakaoMap.getLevel();
-      setLatlng({ latitude: latlng.getLat(), longitude: latlng.getLng() });
-      setScale(scale);
+      setPosition({ latitude, longitude, scale });
     };
 
-    kakao.maps.event.addListener(kakaoMap, 'dragend', changeCenter);
-    kakao.maps.event.addListener(kakaoMap, 'zoom_changed', changeScale);
+    kakao.maps.event.addListener(kakaoMap, 'idle', updatePosition);
     return () => {
-      kakao.maps.event.removeListener(kakaoMap, 'dragend', changeCenter);
-      kakao.maps.event.removeListener(kakaoMap, 'zoom_changed', changeScale);
+      kakao.maps.event.removeListener(kakaoMap, 'idle', updatePosition);
     };
   }, []);
 
   useEffect(() => {
+    (async () => {
+      const { latitude, longitude, scale } = position;
+      const region = (await coordToRegionCode(latitude, longitude)) as {
+        result: Array<string>;
+        status: string;
+      };
+      if (region.status !== kakao.maps.services.Status.OK) return;
+
+      const newRange = {
+        region: region.result,
+        scale: scale,
+      };
+
+      setRange((oldRange) => {
+        if (isRangeEqual(oldRange, newRange)) return oldRange;
+        return newRange;
+      });
+    })();
+  }, [position]);
+
+  useEffect(() => {
+    const { scale, region } = range;
+    const managePolygon = async () => {
+      const regions = await requestCoord(scale, region);
+      const polygons = createPolygons(regions);
+      setPolygons(polygons);
+    };
+    managePolygon();
+  }, [range]);
+
+  useEffect(() => {
     if (!map) return;
 
-    const managePolygon = async () => {
-      // 중심 좌표의 주소 가져오기
-      const region: { result: Array<string>; status: string } =
-        (await coordToRegionCode(latitude, longitude)) as {
-          result: Array<string>;
-          status: string;
-        };
-
-      if (region.status !== 'OK') return;
-      // 백엔드 요청
-      const regions = await requestCoord(scale, region.result);
-      // 폴리곤 그리기
-      polygonInstances.current = drawPolygon(
-        map,
-        regions,
-        polygonInstances.current,
-      );
-    };
-
-    managePolygon();
-
-    return () => {
-      if (polygonInstances.current !== null) {
-        deletePolygon(polygonInstances.current);
-      }
-    };
-  }, [map, scale, latitude, longitude]);
+    displayPolygons(polygons, map);
+    return () => deletePolygons(polygons);
+  }, [map, polygons]);
 
   useEffect(() => {
     (async () => {
-      const markerInfos = await requestMarkerInfo(scale, [
-        '서울특별시',
-        '용산구',
-      ]);
+      const { scale, region } = range;
+      const markerInfos = await requestMarkerInfo(scale, region);
       const markers = createMarkers(markerInfos);
       setMarkers(markers);
     })();
-  }, [scale]);
+  }, [range]);
 
   useEffect(() => {
     if (!map) return;
 
     displayMarkers(markers, map);
-    return () => {
-      console.log(markers);
-      hideMarkers(markers);
-    };
+    return () => deleteMarkers(markers);
   }, [map, markers]);
 
   return <MapWrapper ref={mapWrapper} />;

--- a/client/src/components/Map/index.tsx
+++ b/client/src/components/Map/index.tsx
@@ -75,7 +75,7 @@ const Map: React.FC = () => {
   }, []);
 
   useEffect(() => {
-    (async () => {
+    const updateRange = async () => {
       const { latitude, longitude, scale } = position;
       const region = (await coordToRegionCode(latitude, longitude)) as {
         result: Array<string>;
@@ -92,17 +92,18 @@ const Map: React.FC = () => {
         if (isRangeEqual(oldRange, newRange)) return oldRange;
         return newRange;
       });
-    })();
+    };
+    updateRange();
   }, [position]);
 
   useEffect(() => {
     const { scale, region } = range;
-    const managePolygon = async () => {
+    const updatePolygons = async () => {
       const regions = await requestCoord(scale, region);
       const polygons = createPolygons(regions);
       setPolygons(polygons);
     };
-    managePolygon();
+    updatePolygons();
   }, [range]);
 
   useEffect(() => {
@@ -113,12 +114,13 @@ const Map: React.FC = () => {
   }, [map, polygons]);
 
   useEffect(() => {
-    (async () => {
+    const updateMarkers = async () => {
       const { scale, region } = range;
       const markerInfos = await requestMarkerInfo(scale, region);
       const markers = createMarkers(markerInfos);
       setMarkers(markers);
-    })();
+    };
+    updateMarkers();
   }, [range]);
 
   useEffect(() => {

--- a/client/src/controllers/markerController.ts
+++ b/client/src/controllers/markerController.ts
@@ -1,4 +1,4 @@
-import { $marker, $largeMarker } from '@utils/marker';
+import { markerEl, largeMarkerEl } from '@utils/marker';
 
 type MarkerInfo = {
   address: string;
@@ -71,12 +71,12 @@ const createMarkers = (
 
 const markerDefault = (markerInfo: MarkerInfo) => {
   const { rates } = markerInfo;
-  return $marker(rates);
+  return markerEl(rates);
 };
 
 const markerMouseOver = (markerInfo: MarkerInfo) => {
   const { address, rates } = markerInfo;
-  return $largeMarker(address, rates);
+  return largeMarkerEl(address, rates);
 };
 
 const displayMarkers = (

--- a/client/src/controllers/markerController.ts
+++ b/client/src/controllers/markerController.ts
@@ -58,7 +58,6 @@ const createMarkers = (
     const largeMarker = markerMouseOver(markerInfo);
 
     defaultMarker.addEventListener('mouseover', () => {
-      console.log(markerInfo.center);
       marker.setContent(largeMarker);
     });
     largeMarker.addEventListener('mouseout', () =>

--- a/client/src/controllers/markerController.ts
+++ b/client/src/controllers/markerController.ts
@@ -1,0 +1,89 @@
+type MarkerInfo = {
+  address: string;
+  center: [number, number];
+  rates: {
+    safety: number;
+    traffic: number;
+    food: number;
+    entertainment: number;
+  };
+};
+
+// test
+const random = (from: number, to: number) => {
+  return Math.random() * (to - from) + from;
+};
+
+const getRandomLatLng = () => {
+  return [random(33, 38), random(124, 132)];
+};
+
+const getRandomRate = () => {
+  return random(0, 5);
+};
+
+const average = (...values: number[]) => {
+  const sum = values.reduce((a, b) => a + b, 0);
+  return (sum / values.length || 0).toFixed(2);
+};
+
+// TODO: fetch 요청
+const requestMarkerInfo = async (
+  scale: number,
+  region: string[],
+): Promise<MarkerInfo[]> => {
+  console.log(scale, region);
+  return Array(20)
+    .fill(0)
+    .map(() => {
+      return {
+        address: '서울특별시 송파구',
+        center: getRandomLatLng() as [number, number],
+        rates: {
+          safety: getRandomRate(),
+          traffic: getRandomRate(),
+          food: getRandomRate(),
+          entertainment: getRandomRate(),
+        },
+      };
+    });
+};
+
+const createMarkers = (
+  markerInfos: MarkerInfo[],
+): kakao.maps.CustomOverlay[] => {
+  return markerInfos.map((markerInfo) => {
+    const { center } = markerInfo;
+    const content = markerTemplate(markerInfo);
+    return new kakao.maps.CustomOverlay({
+      content: content,
+      position: new kakao.maps.LatLng(...center),
+    });
+  });
+};
+
+const markerTemplate = (markerInfo: MarkerInfo) => {
+  const { address, rates } = markerInfo;
+  const averageRate = average(
+    ...Object.keys(rates).map((category) => rates[category]),
+  );
+  return `
+    <div style="background-color: rgb(0, 0, 0, 0.6)">
+      <span>${address}</span>
+      <span>${averageRate}</span>
+    </div>
+  `;
+};
+
+const displayMarkers = (
+  markers: kakao.maps.CustomOverlay[],
+  map: kakao.maps.Map,
+) => {
+  markers.forEach((marker) => marker.setMap(map));
+};
+
+const hideMarkers = (markers: kakao.maps.CustomOverlay[]) => {
+  markers.forEach((marker) => marker.setMap(null));
+};
+
+export { requestMarkerInfo, createMarkers, displayMarkers, hideMarkers };

--- a/client/src/controllers/markerController.ts
+++ b/client/src/controllers/markerController.ts
@@ -32,12 +32,11 @@ const requestMarkerInfo = async (
   scale: number,
   region: string[],
 ): Promise<MarkerInfo[]> => {
-  console.log(scale, region);
-  return Array(20)
+  return Array(100)
     .fill(0)
     .map(() => {
       return {
-        address: '서울특별시 송파구',
+        address: region.join(' ') + ` ${scale}`,
         center: getRandomLatLng() as [number, number],
         rates: {
           safety: getRandomRate(),
@@ -82,8 +81,8 @@ const displayMarkers = (
   markers.forEach((marker) => marker.setMap(map));
 };
 
-const hideMarkers = (markers: kakao.maps.CustomOverlay[]) => {
+const deleteMarkers = (markers: kakao.maps.CustomOverlay[]) => {
   markers.forEach((marker) => marker.setMap(null));
 };
 
-export { requestMarkerInfo, createMarkers, displayMarkers, hideMarkers };
+export { requestMarkerInfo, createMarkers, displayMarkers, deleteMarkers };

--- a/client/src/controllers/markerController.ts
+++ b/client/src/controllers/markerController.ts
@@ -1,3 +1,5 @@
+import { $marker, $largeMarker } from '@utils/marker';
+
 type MarkerInfo = {
   address: string;
   center: [number, number];
@@ -11,7 +13,7 @@ type MarkerInfo = {
 
 // test
 const random = (from: number, to: number) => {
-  return Math.random() * (to - from) + from;
+  return Number((Math.random() * (to - from) + from).toFixed(2));
 };
 
 const getRandomLatLng = () => {
@@ -20,11 +22,6 @@ const getRandomLatLng = () => {
 
 const getRandomRate = () => {
   return random(0, 5);
-};
-
-const average = (...values: number[]) => {
-  const sum = values.reduce((a, b) => a + b, 0);
-  return (sum / values.length || 0).toFixed(2);
 };
 
 // TODO: fetch 요청
@@ -53,25 +50,33 @@ const createMarkers = (
 ): kakao.maps.CustomOverlay[] => {
   return markerInfos.map((markerInfo) => {
     const { center } = markerInfo;
-    const content = markerTemplate(markerInfo);
-    return new kakao.maps.CustomOverlay({
-      content: content,
+    const marker = new kakao.maps.CustomOverlay({
       position: new kakao.maps.LatLng(...center),
     });
+
+    const defaultMarker = markerDefault(markerInfo);
+    const largeMarker = markerMouseOver(markerInfo);
+
+    defaultMarker.addEventListener('mouseover', () => {
+      console.log(markerInfo.center);
+      marker.setContent(largeMarker);
+    });
+    largeMarker.addEventListener('mouseout', () =>
+      marker.setContent(defaultMarker),
+    );
+    marker.setContent(defaultMarker);
+    return marker;
   });
 };
 
-const markerTemplate = (markerInfo: MarkerInfo) => {
+const markerDefault = (markerInfo: MarkerInfo) => {
+  const { rates } = markerInfo;
+  return $marker(rates);
+};
+
+const markerMouseOver = (markerInfo: MarkerInfo) => {
   const { address, rates } = markerInfo;
-  const averageRate = average(
-    ...Object.keys(rates).map((category) => rates[category]),
-  );
-  return `
-    <div style="background-color: rgb(0, 0, 0, 0.6)">
-      <span>${address}</span>
-      <span>${averageRate}</span>
-    </div>
-  `;
+  return $largeMarker(address, rates);
 };
 
 const displayMarkers = (

--- a/client/src/utils/marker.ts
+++ b/client/src/utils/marker.ts
@@ -1,0 +1,127 @@
+type RateType = {
+  safety: number;
+  traffic: number;
+  food: number;
+  entertainment: number;
+};
+
+const average = (...values: number[]) => {
+  const sum = values.reduce((a, b) => a + b, 0);
+  return Number((sum / values.length || 0).toFixed(2));
+};
+
+const rateStyle = `
+  .star-ratings {
+    color: #aaa9a9; 
+    position: relative;
+    unicode-bidi: bidi-override;
+    width: max-content;
+    -webkit-text-fill-color: transparent; /* Will override color (regardless of order) */
+    -webkit-text-stroke-width: 1.3px;
+    -webkit-text-stroke-color: #2b2a29;
+  }
+  
+  .star-ratings-fill {
+    color: #fff58c;
+    padding: 0;
+    position: absolute;
+    z-index: 1;
+    display: flex;
+    top: 0;
+    left: 0;
+    overflow: hidden;
+    -webkit-text-fill-color: gold;
+  }
+  
+  .star-ratings-base {
+    z-index: 0;
+    padding: 0;
+  }
+`;
+
+const markerStyle = `
+  .customoverlay {
+    position: relative;
+    bottom: 15px;
+    border-radius: 6px;
+    border: 1px solid #ccc;
+    border-bottom: 2px solid #ddd;
+    background: #fff;
+    font-weight: bold;
+    float: left;
+  }
+
+  .customoverlay:nth-of-type(n) {
+    border: 0;
+    box-shadow: 0px 1px 2px #888;
+  }
+
+  .customoverlay .title {
+    display: block;
+    text-align: center;
+    padding: 10px 15px;
+  }
+
+  .customoverlay:after {
+    content: '';
+    position: absolute;
+    margin-left: -12px;
+    left: 50%;
+    bottom: -12px;
+    width: 22px;
+    height: 12px;
+    background: url('https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/vertex_white.png');
+  }
+`;
+
+const ratingToPercent = (rate: number) => {
+  return (rate / 5) * 100;
+};
+
+const $starRate = (rate: number) => {
+  const wrapper = document.createElement('div');
+  wrapper.innerHTML = `
+    <style scoped>${rateStyle}</style>
+    <div class="star-ratings">
+      <div class="star-ratings-fill" style="width: ${ratingToPercent(rate)}%">
+        <span>★</span><span>★</span><span>★</span><span>★</span><span>★</span>
+      </div>
+      <div class="star-ratings-base">
+        <span>★</span><span>★</span><span>★</span><span>★</span><span>★</span>
+      </div>
+    </div>
+  `;
+  return wrapper;
+};
+
+const $marker = (rates: RateType) => {
+  const wrapper = document.createElement('div');
+  const averageRate = average(
+    ...Object.keys(rates).map((category) => rates[category]),
+  );
+  wrapper.innerHTML = `
+    <style scoped>${markerStyle}</style>
+    <div class="customoverlay">
+      <div class="title"></div>
+    </div>
+  `;
+  wrapper.querySelector('.title')?.append($starRate(averageRate));
+  return wrapper;
+};
+
+const $largeMarker = (address: string, rates: RateType) => {
+  const wrapper = document.createElement('div');
+  const averageRate = average(
+    ...Object.keys(rates).map((category) => rates[category]),
+  );
+  wrapper.innerHTML = `
+    <div class="customoverlay">
+      <style scoped>${markerStyle}</style>
+      <div class="title">${address}</div>
+      <div class="title">${address}</div>
+    </div>
+  `;
+  return wrapper;
+};
+
+export { $marker, $largeMarker };

--- a/client/src/utils/marker.ts
+++ b/client/src/utils/marker.ts
@@ -78,7 +78,7 @@ const ratingToPercent = (rate: number) => {
   return (rate / 5) * 100;
 };
 
-const $starRate = (rate: number) => {
+const starRateEl = (rate: number) => {
   const wrapper = document.createElement('div');
   wrapper.innerHTML = `
     <style scoped>${rateStyle}</style>
@@ -94,7 +94,7 @@ const $starRate = (rate: number) => {
   return wrapper;
 };
 
-const $marker = (rates: RateType) => {
+const markerEl = (rates: RateType) => {
   const wrapper = document.createElement('div');
   const averageRate = average(
     ...Object.keys(rates).map((category) => rates[category]),
@@ -105,11 +105,11 @@ const $marker = (rates: RateType) => {
       <div class="title"></div>
     </div>
   `;
-  wrapper.querySelector('.title')?.append($starRate(averageRate));
+  wrapper.querySelector('.title')?.append(starRateEl(averageRate));
   return wrapper;
 };
 
-const $largeMarker = (address: string, rates: RateType) => {
+const largeMarkerEl = (address: string, rates: RateType) => {
   const wrapper = document.createElement('div');
   const averageRate = average(
     ...Object.keys(rates).map((category) => rates[category]),
@@ -118,10 +118,10 @@ const $largeMarker = (address: string, rates: RateType) => {
     <div class="customoverlay">
       <style scoped>${markerStyle}</style>
       <div class="title">${address}</div>
-      <div class="title">${address}</div>
+      <div class="title">${averageRate}</div>
     </div>
   `;
   return wrapper;
 };
 
-export { $marker, $largeMarker };
+export { markerEl, largeMarkerEl };


### PR DESCRIPTION
### 🔨 작업 내용 설명
- 현재 보고 있는 구역(`range`)을 상태로 관리하여 중복된 폴리곤 데이터 요청을 방지
- 폴리곤 그리는 코드 리팩토링
- Map API를 활용하여 임의의 위치에 마커 띄우기
- 기본 마커를 5성 별점으로 채우기

### 📑 구현한 내용
- 경기도를 보고 있을 때 드래그하여 다시 경기도로 이동하면 "깜빡임 없이" 폴리곤이 유지됩니다. 드래그, 줌 변경시 같은 폴리곤이 그려져야 하는 경우에 다시 그리지 않습니다. 
- 마커 기본형(마우스 올리지 않았을 때)을 스타일링하였습니다. 스크린샷 참고.
- 랜덤 함수를 사용해 임의의 별점을 가지는 마커를 임의의 위치에 뿌려뒀습니다. API 구현 후 적절한 위치에 배치할 수 있을 것입니다. 
- 마커에 마우스를 올리면 내용이 변화하도록 이벤트 리스너(`mouseover`)를 추가했습니다. 마커가 커졌을 때 위치 조정이 필요합니다. 

### 🚧 주의 사항
- 폴리곤의 배열을 상태로 관리하도록 리팩토링했습니다. `useRef`보다 깔끔하다고 생각합니다... 과연?

### 스크린 샷
![스크린샷(130)](https://user-images.githubusercontent.com/24454874/140775977-725f84f0-6557-4139-94c7-a87bb79a1794.png)

closes #39 
