### PR TITLE
[Feat/map_search] 검색 기능 구형

### DIFF
--- a/client/src/assets/icons/search.svg
+++ b/client/src/assets/icons/search.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M11 19C15.4183 19 19 15.4183 19 11C19 6.58172 15.4183 3 11 3C6.58172 3 3 6.58172 3 11C3 15.4183 6.58172 19 11 19Z" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M21 21L16.65 16.65" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/client/src/components/Map/index.tsx
+++ b/client/src/components/Map/index.tsx
@@ -1,4 +1,5 @@
 import MapWrapper from '@components/Map/index.style';
+import Searchbar from '@components/Searchbar/index';
 
 import {
   getCurrentLocation,
@@ -133,7 +134,11 @@ const MapComponent: React.FC = () => {
     return () => deleteMarkers(markers);
   }, [map, markers]);
 
-  return <MapWrapper ref={mapWrapper} />;
+  return (
+    <MapWrapper ref={mapWrapper}>
+      <Searchbar />
+    </MapWrapper>
+  );
 };
 
 export default MapComponent;

--- a/client/src/components/Map/index.tsx
+++ b/client/src/components/Map/index.tsx
@@ -3,7 +3,6 @@ import Searchbar from '@components/Searchbar/index';
 
 import {
   getCurrentLocation,
-  requestCoord,
   coordToRegionCode,
   isRangeEqual,
   createPolygons,

--- a/client/src/components/Map/index.tsx
+++ b/client/src/components/Map/index.tsx
@@ -136,7 +136,7 @@ const MapComponent: React.FC = () => {
 
   return (
     <MapWrapper ref={mapWrapper}>
-      <Searchbar />
+      <Searchbar map={map} />
     </MapWrapper>
   );
 };

--- a/client/src/components/Searchbar/index.style.tsx
+++ b/client/src/components/Searchbar/index.style.tsx
@@ -40,4 +40,51 @@ const SearchImg = styled.img`
 `;
 SearchImg.defaultProps = { src: search };
 
-export { SearchbarWrapper, SearchbarInput, SearchbarButton, SearchImg };
+const DropdownWrapper = styled.div`
+  position: relative;
+  top: 20px;
+  left: 40px;
+  width: 310px;
+  height: auto;
+  background: #fff;
+  border-radius: 10px;
+  border: solid 1px #c5c5c5;
+  z-index: 1000;
+  max-height: 600px;
+  overflow-x: hidden;
+  overflow-y: scroll;
+  &::-webkit-scrollbar {
+    width: 10px;
+    background: none;
+  }
+  &::-webkit-scrollbar-thumb {
+    background: #c5c5c5;
+    border-radius: 999px;
+  }
+`;
+
+const DropdownItem = styled.div`
+  position: relative;
+  width: 300px;
+  height: 50px;
+  padding: 10px 10px;
+  background: #fff;
+  z-index: 1000;
+  ::after {
+    margin-top: 20px;
+    display: block;
+    top: 50px;
+    content: '';
+    width: 280px;
+    border-bottom: solid 1px #c5c5c5;
+  }
+`;
+
+export {
+  SearchbarWrapper,
+  SearchbarInput,
+  SearchbarButton,
+  SearchImg,
+  DropdownWrapper,
+  DropdownItem,
+};

--- a/client/src/components/Searchbar/index.style.tsx
+++ b/client/src/components/Searchbar/index.style.tsx
@@ -31,7 +31,6 @@ const SearchbarButton = styled.button`
   border-radius: 20px;
   border: none;
   background-color: #33ab74;
-  cursor: pointer;
 `;
 
 const SearchImg = styled.img`
@@ -70,6 +69,10 @@ const DropdownItem = styled.div`
   padding: 10px 10px;
   background: #fff;
   z-index: 1000;
+  cursor: pointer;
+  :hover {
+    background: #c5c5c5;
+  }
   ::after {
     margin-top: 20px;
     display: block;

--- a/client/src/components/Searchbar/index.style.tsx
+++ b/client/src/components/Searchbar/index.style.tsx
@@ -1,0 +1,43 @@
+import styled from 'styled-components';
+import search from '@assets/icons/search.svg';
+
+const SearchbarWrapper = styled.div`
+  position: relative;
+  top: 20px;
+  left: 20px;
+  width: 400px;
+  height: 60px;
+  padding-left: 20px;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  background: #fff;
+  border: solid 2px #33ab74;
+  border-radius: 20px;
+  z-index: 1000;
+`;
+
+const SearchbarInput = styled.input`
+  width: 300px;
+  height: 50px;
+  outline: none;
+  border: none;
+`;
+
+const SearchbarButton = styled.button`
+  width: 60px;
+  height: 60px;
+  border-radius: 20px;
+  border: none;
+  background-color: #33ab74;
+  cursor: pointer;
+`;
+
+const SearchImg = styled.img`
+  width: 80%;
+  height: 80%;
+`;
+SearchImg.defaultProps = { src: search };
+
+export { SearchbarWrapper, SearchbarInput, SearchbarButton, SearchImg };

--- a/client/src/components/Searchbar/index.tsx
+++ b/client/src/components/Searchbar/index.tsx
@@ -3,18 +3,51 @@ import {
   SearchbarInput,
   SearchbarButton,
   SearchImg,
+  DropdownWrapper,
+  DropdownItem,
 } from '@components/Searchbar/index.style';
+import { spreadDropdown } from '@controllers/searchbarController';
 
-import React from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 
-const Searchbar: React.FC = (props) => {
+interface SearchbarProps {
+  map: kakao.maps.Map | null;
+}
+
+const Searchbar: React.FC<SearchbarProps> = ({ map }) => {
+  const [input, setInput] = useState('');
+  const [results, setResults] = useState([]);
+  const isSpread = useRef(false);
+
+  const places = useRef<kakao.maps.services.Places | null>(null);
+
+  useEffect(() => {
+    if (map !== null) {
+      places.current = new kakao.maps.services.Places(map);
+    }
+  }, [map]);
+
+  useEffect(() => {
+    if (places.current !== null) {
+      spreadDropdown(places.current, input, isSpread.current, setResults);
+    }
+  }, [input]);
+
   return (
-    <SearchbarWrapper>
-      <SearchbarInput />
-      <SearchbarButton>
-        <SearchImg />
-      </SearchbarButton>
-    </SearchbarWrapper>
+    <>
+      <SearchbarWrapper>
+        <SearchbarInput onChange={(e) => setInput(e.target.value)} />
+        <SearchbarButton>
+          <SearchImg />
+        </SearchbarButton>
+      </SearchbarWrapper>
+      <DropdownWrapper>
+        {results.length > 0 &&
+          results.map((result, i) => (
+            <DropdownItem key={i}>{result}</DropdownItem>
+          ))}
+      </DropdownWrapper>
+    </>
   );
 };
 

--- a/client/src/components/Searchbar/index.tsx
+++ b/client/src/components/Searchbar/index.tsx
@@ -6,7 +6,11 @@ import {
   DropdownWrapper,
   DropdownItem,
 } from '@components/Searchbar/index.style';
-import { SimpleMap, spreadDropdown } from '@controllers/searchbarController';
+import {
+  SimpleMap,
+  spreadDropdown,
+  moveTo,
+} from '@controllers/searchbarController';
 
 import React, { useEffect, useState, useRef } from 'react';
 
@@ -19,13 +23,7 @@ const Searchbar: React.FC<SearchbarProps> = ({ map }) => {
   const [results, setResults] = useState<SimpleMap[]>([]);
   const isSpread = useRef(false);
 
-  const places = useRef<kakao.maps.services.Places | null>(null);
-
-  useEffect(() => {
-    if (map !== null) {
-      places.current = new kakao.maps.services.Places(map);
-    }
-  }, [map]);
+  const inputTagRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     spreadDropdown(input, isSpread.current, setResults);
@@ -34,7 +32,10 @@ const Searchbar: React.FC<SearchbarProps> = ({ map }) => {
   return (
     <>
       <SearchbarWrapper>
-        <SearchbarInput onChange={(e) => setInput(e.target.value)} />
+        <SearchbarInput
+          onChange={(e) => setInput(e.target.value)}
+          ref={inputTagRef}
+        />
         <SearchbarButton>
           <SearchImg />
         </SearchbarButton>
@@ -42,7 +43,14 @@ const Searchbar: React.FC<SearchbarProps> = ({ map }) => {
       <DropdownWrapper>
         {results.length > 0 &&
           results.map((result, i) => (
-            <DropdownItem key={i}>{result.name}</DropdownItem>
+            <DropdownItem
+              key={i}
+              onClick={(e) =>
+                moveTo(map, results[i], setResults, inputTagRef.current)
+              }
+            >
+              {result.name}
+            </DropdownItem>
           ))}
       </DropdownWrapper>
     </>

--- a/client/src/components/Searchbar/index.tsx
+++ b/client/src/components/Searchbar/index.tsx
@@ -1,0 +1,21 @@
+import {
+  SearchbarWrapper,
+  SearchbarInput,
+  SearchbarButton,
+  SearchImg,
+} from '@components/Searchbar/index.style';
+
+import React from 'react';
+
+const Searchbar: React.FC = (props) => {
+  return (
+    <SearchbarWrapper>
+      <SearchbarInput />
+      <SearchbarButton>
+        <SearchImg />
+      </SearchbarButton>
+    </SearchbarWrapper>
+  );
+};
+
+export default Searchbar;

--- a/client/src/components/Searchbar/index.tsx
+++ b/client/src/components/Searchbar/index.tsx
@@ -6,7 +6,7 @@ import {
   DropdownWrapper,
   DropdownItem,
 } from '@components/Searchbar/index.style';
-import { spreadDropdown } from '@controllers/searchbarController';
+import { SimpleMap, spreadDropdown } from '@controllers/searchbarController';
 
 import React, { useEffect, useState, useRef } from 'react';
 
@@ -16,7 +16,7 @@ interface SearchbarProps {
 
 const Searchbar: React.FC<SearchbarProps> = ({ map }) => {
   const [input, setInput] = useState('');
-  const [results, setResults] = useState([]);
+  const [results, setResults] = useState<SimpleMap[]>([]);
   const isSpread = useRef(false);
 
   const places = useRef<kakao.maps.services.Places | null>(null);
@@ -28,9 +28,7 @@ const Searchbar: React.FC<SearchbarProps> = ({ map }) => {
   }, [map]);
 
   useEffect(() => {
-    if (places.current !== null) {
-      spreadDropdown(places.current, input, isSpread.current, setResults);
-    }
+    spreadDropdown(input, isSpread.current, setResults);
   }, [input]);
 
   return (
@@ -44,7 +42,7 @@ const Searchbar: React.FC<SearchbarProps> = ({ map }) => {
       <DropdownWrapper>
         {results.length > 0 &&
           results.map((result, i) => (
-            <DropdownItem key={i}>{result}</DropdownItem>
+            <DropdownItem key={i}>{result.name}</DropdownItem>
           ))}
       </DropdownWrapper>
     </>

--- a/client/src/controllers/searchbarController.ts
+++ b/client/src/controllers/searchbarController.ts
@@ -30,5 +30,36 @@ const spreadDropdown = async (keyword, isSpread, setResults) => {
   }
 };
 
-export { spreadDropdown };
+const moveTo = (
+  map: kakao.maps.Map | null,
+  to: SimpleMap,
+  setResults,
+  inputTagRef,
+) => {
+  if (map === null) {
+    return;
+  }
+  const [x, y] = to.center;
+  const newCenter = new kakao.maps.LatLng(x, y);
+  map.setCenter(newCenter);
+  let newLevel = 9;
+  switch (to.codeLength) {
+    case 2:
+      newLevel = 11;
+      break;
+    case 5:
+      newLevel = 8;
+      break;
+    case 7:
+      newLevel = 6;
+      break;
+    default:
+      break;
+  }
+  map.setLevel(newLevel);
+  inputTagRef.value = '';
+  setResults([]);
+};
+
+export { spreadDropdown, moveTo };
 export type { SimpleMap };

--- a/client/src/controllers/searchbarController.ts
+++ b/client/src/controllers/searchbarController.ts
@@ -1,0 +1,34 @@
+interface SearchResult {
+  status: kakao.maps.services.Status;
+  result: any;
+}
+
+const spreadDropdown = async (ps, keyword, isSpread, setResults) => {
+  const searchRegions = async (): Promise<SearchResult> => {
+    return await new Promise((resolve, reject) => {
+      ps.keywordSearch(keyword, (result, status) => {
+        resolve({ status, result });
+      });
+    });
+  };
+
+  const setDropdown = (_results, _isSpread) => {
+    setResults(_results);
+    isSpread = _isSpread;
+  };
+
+  if (keyword.length === 0) {
+    return setDropdown([], false);
+  }
+  const { status, result }: SearchResult = await searchRegions();
+  if (status === kakao.maps.services.Status.OK) {
+    setDropdown(
+      result.map((r) => `${r.place_name}\n${r.address_name}`),
+      true,
+    );
+  } else {
+    setDropdown([], false);
+  }
+};
+
+export { spreadDropdown };

--- a/client/src/controllers/searchbarController.ts
+++ b/client/src/controllers/searchbarController.ts
@@ -1,15 +1,20 @@
-interface SearchResult {
-  status: kakao.maps.services.Status;
-  result: any;
+type CoordType = [number, number];
+
+interface SimpleMap {
+  name: string;
+  codeLength: number;
+  center: CoordType;
 }
 
-const spreadDropdown = async (ps, keyword, isSpread, setResults) => {
-  const searchRegions = async (): Promise<SearchResult> => {
-    return await new Promise((resolve, reject) => {
-      ps.keywordSearch(keyword, (result, status) => {
-        resolve({ status, result });
+const spreadDropdown = async (keyword, isSpread, setResults) => {
+  const searchRegions = async (): Promise<SimpleMap[] | []> => {
+    return await fetch(
+      `http://${process.env.REACT_APP_SERVER_HOST}/api/map/search?keyword=${keyword}`,
+    )
+      .then(async (response) => await response.json())
+      .catch((err) => {
+        console.error(err);
       });
-    });
   };
 
   const setDropdown = (_results, _isSpread) => {
@@ -17,18 +22,13 @@ const spreadDropdown = async (ps, keyword, isSpread, setResults) => {
     isSpread = _isSpread;
   };
 
-  if (keyword.length === 0) {
-    return setDropdown([], false);
-  }
-  const { status, result }: SearchResult = await searchRegions();
-  if (status === kakao.maps.services.Status.OK) {
-    setDropdown(
-      result.map((r) => `${r.place_name}\n${r.address_name}`),
-      true,
-    );
+  const result: SimpleMap[] | [] = await searchRegions();
+  if (result.length > 0) {
+    setDropdown(result, true);
   } else {
     setDropdown([], false);
   }
 };
 
 export { spreadDropdown };
+export type { SimpleMap };

--- a/server/src/api/adminController.ts
+++ b/server/src/api/adminController.ts
@@ -14,7 +14,7 @@ interface MapRequest extends Request {
 
 router.post('/map-data', (req: MapRequest, res: Response) => {
   if (req.body.password === process.env.ADMIN_PASSWORD) {
-    void updateMapService.populateMap();
+    void updateMapService.populateMapAndSimpleMap();
     res.status(200).send('HAHA!');
   } else {
     res.status(404).send('DAMN! 404 NOT FOUND... YOU MAD?');

--- a/server/src/api/mapController.ts
+++ b/server/src/api/mapController.ts
@@ -17,9 +17,11 @@ router.get('/polygon', (async (req: Request, res: Response) => {
 
 router.get('/search', (async (req: Request, res: Response) => {
   const { keyword } = req.query;
-  if (typeof keyword === 'string') {
+  if (typeof keyword === 'string' && keyword.length > 0) {
     const center = await mapService.queryCenter(keyword);
     res.json(center);
+  } else {
+    res.json([]);
   }
 }) as RequestHandler);
 

--- a/server/src/api/mapController.ts
+++ b/server/src/api/mapController.ts
@@ -6,13 +6,19 @@ const router: express.Router = express.Router();
 
 router.get('/polygon', (async (req: Request, res: Response) => {
   const { scale, big, medium, small } = req.query;
-  const polygon = await mapService.queryPolygon(
-    Number(scale),
-    big as string,
-    medium as string,
-    small as string,
-  );
-  res.json(polygon);
+  if (scale && (big || medium || small)) {
+    const polygon = await mapService.queryPolygon(
+      Number(scale),
+      big as string,
+      medium as string,
+      small as string,
+    );
+    res.json(polygon);
+  } else {
+    res.json([
+      { name: '', path: [], code: '', codeLength: 0, center: [], type: '' },
+    ]);
+  }
 }) as RequestHandler);
 
 router.get('/search', (async (req: Request, res: Response) => {

--- a/server/src/api/mapController.ts
+++ b/server/src/api/mapController.ts
@@ -15,4 +15,12 @@ router.get('/polygon', (async (req: Request, res: Response) => {
   res.json(polygon);
 }) as RequestHandler);
 
+router.get('/search', (async (req: Request, res: Response) => {
+  const { keyword } = req.query;
+  if (typeof keyword === 'string') {
+    const center = await mapService.queryCenter(keyword);
+    res.json(center);
+  }
+}) as RequestHandler);
+
 export default router;

--- a/server/src/models/SimpleMap.ts
+++ b/server/src/models/SimpleMap.ts
@@ -1,0 +1,19 @@
+import { Schema, model } from 'mongoose';
+
+type CoordType = [number, number];
+
+interface SimpleMap {
+  name: string;
+  codeLength: number;
+  center: CoordType;
+}
+
+const simpleMapSchema = new Schema<SimpleMap>({
+  name: { type: String, required: true, text: true },
+  codeLength: { type: Number, required: true, index: true },
+  center: { type: [Number, Number], required: true },
+});
+
+const SimpleMapModel = model<SimpleMap>('SimpleMap', simpleMapSchema);
+
+export { SimpleMap, SimpleMapModel };

--- a/server/src/services/index.ts
+++ b/server/src/services/index.ts
@@ -1,4 +1,4 @@
 import mapService from '@services/mapService';
-import updateMapService from './updateMapService';
+import updateMapService from '@services/updateMapService';
 
 export { mapService, updateMapService };

--- a/server/src/services/mapService.ts
+++ b/server/src/services/mapService.ts
@@ -1,33 +1,38 @@
 import { Map, MapModel } from '@models/Map';
+import { SimpleMap, SimpleMapModel } from '@models/SimpleMap';
 
 const queryPolygon = async (
   scale: number,
   big: string,
   medium: string,
   small: string,
-) => {
+): Promise<Map[]> => {
   let result: Map[] = [];
 
   switch (true) {
     case scale < 9:
       result = await MapModel.find({
-        name: { $regex: new RegExp(`^${big} ${medium}`) },
-        code: { $regex: /^.......$/ },
+        $text: { $search: `${big} ${medium}` },
+        codeLength: 7,
       });
       break;
     case 9 <= scale && scale < 12:
       result = await MapModel.find({
-        name: { $regex: new RegExp(`^${big}`) },
-        code: { $regex: /^.....$/ },
+        $text: { $search: `${big}` },
+        codeLength: 5,
       });
       break;
     case 12 <= scale:
       result = await MapModel.find({
-        code: { $regex: /^..$/ },
+        codeLength: 2,
       });
       break;
   }
   return result;
 };
 
-export default { queryPolygon };
+const queryCenter = async (keyword: string): Promise<SimpleMap[]> => {
+  return await SimpleMapModel.find({ name: { $regex: RegExp(keyword, 'g') } });
+};
+
+export default { queryPolygon, queryCenter };

--- a/server/src/services/mapService.ts
+++ b/server/src/services/mapService.ts
@@ -12,7 +12,7 @@ const queryPolygon = async (
   switch (true) {
     case scale < 9:
       result = await MapModel.find({
-        $text: { $search: `${big} ${medium}` },
+        $text: { $search: `${medium}` },
         codeLength: 7,
       });
       break;

--- a/server/src/services/updateMapService.ts
+++ b/server/src/services/updateMapService.ts
@@ -175,10 +175,9 @@ const populateMapAndSimpleMap = async () => {
     });
 
   await MapModel.collection.createIndex({ codeLength: 1, name: 'text' });
-  await SimpleMapModel.collection.createIndex({ codeLength: 1, name: 'text' });
+  await SimpleMapModel.collection.createIndex({ name: 1 });
   const accessToken = await getAuthToken();
   await recursiveGetCoords('', accessToken);
-  logger.info('populate finish!');
 };
 
 export default { populateMapAndSimpleMap };

--- a/server/src/services/updateMapService.ts
+++ b/server/src/services/updateMapService.ts
@@ -1,5 +1,6 @@
 import logger from '@loaders/loggerLoader';
 import { Map, MapModel } from '@models/Map';
+import { SimpleMap, SimpleMapModel } from '@models/SimpleMap';
 
 import axios from 'axios';
 import proj4 from 'proj4';
@@ -129,16 +130,33 @@ const recursiveGetCoords = async (code: string, accessToken: string) => {
       center: [lat, lng],
     };
 
-    MapModel.create(regionData).catch((err) => {
-      logger.error(err);
-    });
-    logger.info(`insert -> ${regionData.name}`);
+    const simpleRegionData: SimpleMap = {
+      codeLength: feature.properties.adm_cd.length,
+      name: feature.properties.adm_nm,
+      center: [lat, lng],
+    };
+
+    MapModel.create(regionData)
+      .then(() => {
+        logger.info(`insert -> ${regionData.name}`);
+      })
+      .catch((err) => {
+        logger.error(err);
+      });
+
+    SimpleMapModel.create(simpleRegionData)
+      .then(() => {
+        logger.info(`insert -> ${simpleRegionData.name} -> simple`);
+      })
+      .catch((err) => {
+        logger.error(err);
+      });
 
     void recursiveGetCoords(feature.properties.adm_cd, accessToken);
   }
 };
 
-const populateMap = async () => {
+const populateMapAndSimpleMap = async () => {
   await MapModel.collection
     .drop()
     .then((result) => {
@@ -147,9 +165,20 @@ const populateMap = async () => {
     .catch((err) => {
       logger.error('Error! : ', err);
     });
+  await SimpleMapModel.collection
+    .drop()
+    .then((result) => {
+      logger.info('Dropped simpleMaps collection');
+    })
+    .catch((err) => {
+      logger.error('Error! : ', err);
+    });
+
   await MapModel.collection.createIndex({ codeLength: 1, name: 'text' });
+  await SimpleMapModel.collection.createIndex({ codeLength: 1, name: 'text' });
   const accessToken = await getAuthToken();
   await recursiveGetCoords('', accessToken);
+  logger.info('populate finish!');
 };
 
-export default { populateMap };
+export default { populateMapAndSimpleMap };


### PR DESCRIPTION
### 🔨 작업 내용 설명
검색기능에 대한 API, 리액트 코드 작성

### 📑 구현한 내용
[검색]
- 검색에 필요한 데이터만 모아놓은 SimpleMap Collection 생성하도록 admin api 수정
- 키워드에 대한 검색 API 구현
- client에서 검색어 입력시 드롭다운으로 검색 리스트 표시
- 리스트 선택시 해당 지역의 알맞은 축척으로 변경, 이동
[버그 수정]
- 축척 레벨 8미만 에서 모든 정보를 다 가져오는 버그 수정
  - text search query는 띄어쓰기를 포함하지 않으므로 big, medium중에서 medium만 사용하여 쿼리하도록 수정
- 한국 지도를 벗어났을 때 한국 전체 보여주는 버그 수정
  - API에서 주소 정보가 충분하지 않으면 빈 Map데이터를 반환하도록 수정 

### 🚧 주의 사항
- 차후에 ES로 하면 검색이더 빨라질것 같다.(지금도 로컬로 했을때는 충분히 빠르게 느껴진다.)
- mongodb의 text 인덱스는 한국말의 형태소 분석을 지원하지 않아서 띄어쓰기 단위로 텍스트를 인덱싱한다. 따라서, '서울'과 같은 검색어로는 '서울특별시 강남구 ...'가 검색되지 않는다. 그래서, 현재는 $regex로 쿼리를 하고 있으며(일반 인덱스 사용) 나름 성능은 로컬에서는 준수하다.

### 스크린샷
![Nov-09-2021 23-56-27](https://user-images.githubusercontent.com/54357553/140948278-f88fbd0a-73df-48e0-9d27-74617c04256b.gif)

closes #41 