### PR TITLE
Fix: #58 - start로 build와 prod 분리

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,4 +81,5 @@ jobs:
             cd donggle-server/server/
             yarn install
             pm2 kill
-            yarn bpd
+            yarn build
+            yarn prod

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -18,11 +18,6 @@ const App: React.FC = () => {
   const location = useLocation();
   const background = location.state && location.state.background;
 
-  useEffect(() => {
-    // 브라우저 API를 이용하여 문서 타이틀을 업데이트합니다.
-    console.log('합쳐져 있는데 reload 파일이 업데이트되었습니다');
-  });
-
   return (
     <>
       <GlobalStyle />

--- a/server/package.json
+++ b/server/package.json
@@ -10,8 +10,7 @@
   "scripts": {
     "dev": "cross-env NODE_ENV=development nodemon --ignore test.json -r tsconfig-paths/register ./src/app.ts",
     "build": "tsc && tscpaths -p tsconfig.json -s ./src -o ./dist",
-    "prod": "cross-env NODE_ENV=production pm2 start ./dist/app.js -i 0",
-    "bpd": "tsc && tscpaths -p tsconfig.json -s ./src -o ./dist && cross-env NODE_ENV=production pm2 start ./dist/app.js -i 0"
+    "prod": "cross-env NODE_ENV=production pm2 start ./dist/app.js -i 0"
   },
   "dependencies": {
     "@types/proj4": "^2.5.2",


### PR DESCRIPTION
pm2 reload는 환경변수를 적용하지 못하는 오류가 있음
build와 prod를 나누어서 나중에 server 파일 build를 github runner에서 할 수 있도록 함

## [ISSUE_TAG] Title

### 🔨 작업 내용 설명

### 📑 구현한 내용

뭐했는지 목록화

### 🚧 주의 사항

기능을 구현하면서 만났던 어려웠던 점.

[### 스크린 샷]

[issue | close] #[ISSUE_NUMBER]
