### PR TITLE
[fix/except_region] 예외 도시 처리

### DIFF
--- a/server/src/services/mapService.ts
+++ b/server/src/services/mapService.ts
@@ -12,7 +12,13 @@ const queryPolygon = async (
   switch (true) {
     case scale < 9:
       result = await MapModel.find({
-        $text: { $search: `${medium}` },
+        /*
+        2921-11-10
+        홍승용
+        형태소가 아닌 문장을 쿼리하려면 escape 해야함
+        */
+        // eslint-disable-next-line no-useless-escape
+        $text: { $search: `\"${big} ${medium}\"` },
         codeLength: 7,
       });
       break;


### PR DESCRIPTION
### 🔨 작업 내용 설명
동구, 세종시와 같은 예외 도시 처리

### 📑 구현한 내용
- 쿼리를 단어(형태소)가 아닌 문장으로 바꾸어서 쿼리하는 형태로 수정 -> 'big medium'
  - 동구와 같은 지역은 시까지 붙여서 쿼리하므로 중복 결과 X
- 세종시는 medium이 비어있으므로, big에 맞는 모든 아이중에서 codeLength가 맞는 친구를 찾아주서어 OK

### 스크린 샷
![image](https://user-images.githubusercontent.com/54357553/141130780-face2c34-ad57-46d2-b721-a957b3013e53.png)

closes #55 
