### PR TITLE
[Feat] 행정구역별 평점 불러와서 마커 띄우기

### DIFF
--- a/client/src/components/Map/index.tsx
+++ b/client/src/components/Map/index.tsx
@@ -16,7 +16,7 @@ import {
   displayMarkers,
   deleteMarkers,
   createMarkerClickListener,
-  requestRates,
+  LFURates,
 } from '@controllers/markerController';
 
 import './markerStyle.css';
@@ -44,7 +44,8 @@ const MapComponent: React.FC<IProps> = ({
 }) => {
   const mapWrapper = useRef<HTMLDivElement | null>(null);
   const [map, setMap] = useState<kakao.maps.Map | null>(null);
-  const cache = useRef(new Map());
+  const polygonCache = useRef(new Map());
+  const markerCache = useRef(new Map());
 
   const [position, setPosition] = useState(DEFAULT_POSITION);
   const [range, setRange] = useState({
@@ -133,7 +134,7 @@ const MapComponent: React.FC<IProps> = ({
   useEffect(() => {
     const { scale, region } = range;
     const updatePolygons = async () => {
-      const regions = await LFURegions(cache.current, scale, region);
+      const regions = await LFURegions(polygonCache.current, scale, region);
       const polygons = createPolygons(regions);
       setPolygons(polygons);
     };
@@ -150,8 +151,12 @@ const MapComponent: React.FC<IProps> = ({
   useEffect(() => {
     const { scale, region } = range;
     const updateMarkers = async () => {
-      const markerInfos = await requestRates(scale, region);
-      const markers = createMarkers(markerInfos);
+      const rates = (await LFURates(
+        markerCache.current,
+        scale,
+        region,
+      )) as RateType[];
+      const markers = createMarkers(rates);
       setMarkers(markers);
     };
     updateMarkers();

--- a/client/src/components/Map/index.tsx
+++ b/client/src/components/Map/index.tsx
@@ -15,8 +15,8 @@ import {
   createMarkers,
   displayMarkers,
   deleteMarkers,
-  regionToMarkerInfo,
   createMarkerClickListener,
+  requestRates,
 } from '@controllers/markerController';
 
 import './markerStyle.css';
@@ -134,13 +134,8 @@ const MapComponent: React.FC<IProps> = ({
     const { scale, region } = range;
     const updatePolygons = async () => {
       const regions = await LFURegions(cache.current, scale, region);
-      console.log(regions);
       const polygons = createPolygons(regions);
       setPolygons(polygons);
-
-      const markerInfos = regions.map((region) => regionToMarkerInfo(region));
-      const markers = createMarkers(markerInfos);
-      setMarkers(markers);
     };
     updatePolygons();
   }, [range]);
@@ -151,6 +146,16 @@ const MapComponent: React.FC<IProps> = ({
     displayPolygons(polygons, map);
     return () => deletePolygons(polygons);
   }, [map, polygons]);
+
+  useEffect(() => {
+    const { scale, region } = range;
+    const updateMarkers = async () => {
+      const markerInfos = await requestRates(scale, region);
+      const markers = createMarkers(markerInfos);
+      setMarkers(markers);
+    };
+    updateMarkers();
+  }, [range]);
 
   useEffect(() => {
     if (!map) return;

--- a/client/src/controllers/mapController.ts
+++ b/client/src/controllers/mapController.ts
@@ -1,7 +1,6 @@
 import ColorHash from 'color-hash';
 
 function getCurrentLocation(callback: (coord: [number, number]) => void) {
-  // const coord: [number, number] = [37.5642135, 127.0016985];
   let coord: [number, number] = [37.5642135, 127.0016985];
 
   const successCallback: PositionCallback = (position) => {

--- a/client/src/controllers/markerController.ts
+++ b/client/src/controllers/markerController.ts
@@ -1,4 +1,3 @@
-import { regionToScaled } from '@utils/address';
 import { RateType } from '@pages/MainPage';
 
 const ratingToPercent = (rate: number) => {
@@ -82,15 +81,11 @@ const random = (from: number, to: number) => {
   return Number((Math.random() * (to - from) + from).toFixed(2));
 };
 
-const getRandomLatLng = () => {
-  return [random(33, 38), random(124, 132)];
-};
-
 const getRandomRate = () => {
   return random(1, 5);
 };
 
-const regionToMarkerInfo = (region): RateType => {
+const regionToRates = (region): RateType => {
   const count = random(0, 100);
   const safety = getRandomRate() * count;
   const traffic = getRandomRate() * count;
@@ -114,28 +109,15 @@ const regionToMarkerInfo = (region): RateType => {
 };
 
 // TODO: fetch 요청
-const requestMarkerInfo = async (
+const requestRates = async (
   scale: number,
   region: string[],
 ): Promise<RateType[]> => {
-  return Array(100)
-    .fill(0)
-    .map(() => {
-      return {
-        address: regionToScaled(region, scale),
-        code: '',
-        codeLength: 0,
-        center: getRandomLatLng() as [number, number],
-        total: 0,
-        count: 0,
-        categories: {
-          safety: getRandomRate(),
-          traffic: getRandomRate(),
-          food: getRandomRate(),
-          entertainment: getRandomRate(),
-        },
-      };
-    });
+  return await fetch(
+    `${process.env.REACT_APP_API_URL}/api/map/rates?scale=${scale}&big=${region[0]}&medium=${region[1]}&small=${region[2]}`,
+  )
+    .then((response) => response.json())
+    .catch((err) => console.error(err));
 };
 
 const createMarkers = (rateDatas: RateType[]): kakao.maps.CustomOverlay[] => {
@@ -198,10 +180,10 @@ const createMarkerClickListener = (
 };
 
 export {
-  requestMarkerInfo,
+  requestRates,
   createMarkers,
   displayMarkers,
   deleteMarkers,
-  regionToMarkerInfo,
+  regionToRates,
   createMarkerClickListener,
 };

--- a/server/src/api/adminController.ts
+++ b/server/src/api/adminController.ts
@@ -21,4 +21,14 @@ router.post('/map-data', (req: MapRequest, res: Response) => {
   }
 });
 
+router.post('/rates', (req: MapRequest, res) => {
+  const { password } = req.body;
+  if (password === process.env.ADMIN_PASSWORD) {
+    void updateMapService.populateMapInfos();
+    res.status(200).send('HAHAHA!');
+  } else {
+    res.status(404).send('FXXK! 404 NOT FOUND.... GET OFF!');
+  }
+});
+
 export default router;

--- a/server/src/api/mapController.ts
+++ b/server/src/api/mapController.ts
@@ -21,6 +21,36 @@ router.get('/polygon', (async (req: Request, res: Response) => {
   }
 }) as RequestHandler);
 
+router.get('/rates', (async (req, res) => {
+  const { scale, big, medium, small } = req.query;
+  if (scale && (big || medium || small)) {
+    const rates = await mapService.queryRates(
+      Number(scale),
+      big as string,
+      medium as string,
+      small as string,
+    );
+    res.json(rates);
+  } else {
+    res.json([
+      {
+        address: '',
+        code: '',
+        codeLength: 0,
+        center: [],
+        total: 0,
+        count: 0,
+        categories: {
+          safety: 0,
+          traffic: 0,
+          food: 0,
+          entertainment: 0,
+        },
+      },
+    ]);
+  }
+}) as RequestHandler);
+
 router.get('/search', (async (req: Request, res: Response) => {
   const { keyword } = req.query;
   if (typeof keyword === 'string' && keyword.length > 0) {

--- a/server/src/services/mapService.ts
+++ b/server/src/services/mapService.ts
@@ -41,4 +41,57 @@ const queryCenter = async (keyword: string): Promise<MapInfo[]> => {
   return await MapInfoModel.find({ address: { $regex: RegExp(keyword, 'g') } });
 };
 
-export default { queryPolygon, queryCenter };
+const queryRates = async (
+  scale: number,
+  big: string,
+  medium: string,
+  small: string,
+) => {
+  let result: MapInfo[] = [];
+  const fields = {
+    address: 1,
+    code: 1,
+    codeLength: 1,
+    center: 1,
+    total: '$rate.total',
+    count: '$rate.count',
+    categories: {
+      safety: '$rate.safety',
+      traffic: '$rate.traffic',
+      food: '$rate.food',
+      entertainment: '$rate.entertainment',
+    },
+  };
+
+  switch (true) {
+    case scale < 9:
+      result = await MapInfoModel.find(
+        {
+          $text: { $search: `"${big} ${medium}"` },
+          codeLength: 7,
+        },
+        fields,
+      );
+      break;
+    case 9 <= scale && scale < 12:
+      result = await MapInfoModel.find(
+        {
+          $text: { $search: `${big}` },
+          codeLength: 5,
+        },
+        fields,
+      );
+      break;
+    case 12 <= scale:
+      result = await MapInfoModel.find(
+        {
+          codeLength: 2,
+        },
+        fields,
+      );
+      break;
+  }
+  return result;
+};
+
+export default { queryPolygon, queryCenter, queryRates };

--- a/server/src/services/updateMapService.ts
+++ b/server/src/services/updateMapService.ts
@@ -182,4 +182,34 @@ const populateMapAndSimpleMap = async (): Promise<void> => {
   await recursiveGetCoords('', accessToken);
 };
 
-export default { populateMapAndSimpleMap };
+const random = (from: number, to: number) => {
+  return Number((Math.random() * (to - from) + from).toFixed(2));
+};
+
+const getRandomRate = () => {
+  return random(1, 5);
+};
+
+const populateMapInfos = async () => {
+  (await MapInfoModel.find({})).forEach((doc) => {
+    const count = Math.floor(random(0, 100));
+    const safety = Math.floor(getRandomRate() * count);
+    const traffic = Math.floor(getRandomRate() * count);
+    const food = Math.floor(getRandomRate() * count);
+    const entertainment = Math.floor(getRandomRate() * count);
+    const total = (safety + traffic + food + entertainment) / 4;
+    const rate = {
+      count,
+      total,
+      safety,
+      traffic,
+      food,
+      entertainment,
+    };
+    void doc.updateOne({ rate: rate }, {}, (err, result) => {
+      if (err) logger.error(`Update failed for ${doc.address}`);
+    });
+  });
+};
+
+export default { populateMapAndSimpleMap, populateMapInfos };


### PR DESCRIPTION
### 🔨 작업 내용 설명
- 마커에 실제로 유의미한 데이터가 들어가도록 백엔드 API 및 프론트엔드 `fetch` 구현

### 📑 구현한 내용
- `MapInfos` 컬렉션에 지역별로 임의의 평점을 채우는 스크립트 작성
- 현재 보고 있는 구역에 대한 지역별 평점을 반환하는 API 엔드포인트 구현 `/api/map/rates`
- 지역별 평점을 불러오는 `fetch` 구현
- `fetch`된 평점 정보를 기반으로 마커를 띄우도록 구현
- 지역별 평점 정보에 LFU 캐싱을 적용
- 평점 또는 후기가 등록되지 않은 지역에 대한 마커 표시 예외처리

### 🚧 주의 사항
- DB에 임의의 평점 정보를 채우려면 `/admin/rates`로 POST 요청을 보내야 합니다. 
- 지역별 포함관계와 상관없이 랜덤한 count를 집어넣습니다.
  - 예를 들어, 실제 후기는 서울시 > 서울시 용산구 > 서울시 용산구 후암동 순으로 많지만 `/admin/rates`로 요청을 보내면 임의의 값을 넣습니다. 

### 스크린 샷
- 지역을 이동해도 평점이 유지되는 것을 확인할 수 있습니다.
- "군포시"에 평점이 0개인데, 예외적으로 표시됩니다. 
![스크린샷(147)](https://user-images.githubusercontent.com/24454874/141270620-7442ccaa-3557-48ad-b6b3-33c2a9707cbc.png)
![스크린샷(148)](https://user-images.githubusercontent.com/24454874/141270628-b78a67b2-05c3-44e1-9af2-6b91bda031c5.png)
![스크린샷(149)](https://user-images.githubusercontent.com/24454874/141270634-59d7196c-fab5-4398-8e08-01586944ccb1.png)

close #71