### PR TITLE
[Feat] 후기 작성 Modal UI 구현

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -20,6 +20,7 @@
     "dotenv": "^10.0.0",
     "proj4": "^2.7.5",
     "react": "^17.0.2",
+    "react-confirm-alert": "^2.7.0",
     "react-dom": "^17.0.2",
     "react-router-dom": "^5.3.0",
     "react-scripts": "4.0.3",

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-children-prop */
 import {
   NotFoundPage,
   MainPage,
@@ -6,12 +5,13 @@ import {
   RankingPage,
   LoginPage,
 } from '@pages/index';
+import ReviewModal from '@components/ReviewModal';
 import { GlobalStore } from '@stores/index';
 import GlobalStyle from '@styledComponents/GlobalStyle';
 import { ThemeProvider } from 'styled-components';
 import myTheme from '@styledComponents/theme';
 
-import React, { useEffect } from 'react';
+import React from 'react';
 import { Switch, Route, useLocation } from 'react-router-dom';
 
 const App: React.FC = () => {
@@ -26,10 +26,10 @@ const App: React.FC = () => {
           <Switch location={background || location}>
             <Route exact path="/" component={MainPage} />
             <Route path="/review" component={ReviewPage} />
-            <Route path="/ranking" component={RankingPage} />
             <Route path="/login" component={LoginPage} />
             <Route component={NotFoundPage} />
           </Switch>
+          {background && <Route path="/write-review" component={ReviewModal} />}
           {background && <Route path="/ranking" component={RankingPage} />}
           {background && <Route path="/login" component={LoginPage} />}
         </GlobalStore>

--- a/client/src/components/Common/BarRate/index.tsx
+++ b/client/src/components/Common/BarRate/index.tsx
@@ -10,14 +10,8 @@ import {
 } from './index.style';
 import { Category } from '@utils/enum';
 
-interface IProps {
+interface IProps extends CategoryRateType {
   count: number;
-  categories: {
-    safety: number;
-    traffic: number;
-    food: number;
-    entertainment: number;
-  };
 }
 
 const BarRateDiv: React.FC<IProps> = ({ count, categories }) => {

--- a/client/src/components/Common/BarRate/index.tsx
+++ b/client/src/components/Common/BarRate/index.tsx
@@ -8,13 +8,7 @@ import {
   RateCategoryBar,
   RateCategoryNum,
 } from './index.style';
-
-enum Category {
-  safety = '치안',
-  traffic = '교통',
-  food = '음식',
-  entertainment = '놀거리',
-}
+import { Category } from '@utils/enum';
 
 interface IProps {
   count: number;

--- a/client/src/components/Common/DynamicStarRate/index.style.tsx
+++ b/client/src/components/Common/DynamicStarRate/index.style.tsx
@@ -1,0 +1,57 @@
+import styled from 'styled-components';
+
+const BaseDiv = styled.div`
+  position: relative;
+  display: flex;
+  width: 100%;
+  justify-content: space-between;
+  align-items: center;
+  line-height: 40px;
+`;
+
+const RateStarDiv = styled(BaseDiv)`
+  width: 100%;
+  justify-content: center;
+  position: relative;
+  overflow: hidden;
+  color: ${(props) => props.theme.colors.lightgrey};
+`;
+
+const RateStarFillDiv = styled.div<{ rate: number }>`
+  color: gold;
+  padding: 0;
+  position: relative;
+  z-index: 1;
+  display: flex;
+  justify-content: space-between;
+  width: ${(props) => props.rate * 20}%;
+  overflow: hidden;
+`;
+
+const CategorySpanDiv = styled(BaseDiv)`
+  width: 50%;
+  padding-left: 100px;
+`;
+
+const CategorySpan = styled.span`
+  display: block;
+  width: 100%;
+  font-size: 15px;
+  color: ${(props) => props.theme.colors.ashgrey};
+  text-align: center;
+  font-weight: bold;
+`;
+
+const StarRateDiv = styled(BaseDiv)`
+  justify-content: center;
+  padding-right: 100px;
+`;
+
+export {
+  BaseDiv,
+  RateStarDiv,
+  RateStarFillDiv,
+  CategorySpanDiv,
+  CategorySpan,
+  StarRateDiv,
+};

--- a/client/src/components/Common/DynamicStarRate/index.style.tsx
+++ b/client/src/components/Common/DynamicStarRate/index.style.tsx
@@ -45,6 +45,22 @@ const CategorySpan = styled.span`
 const StarRateDiv = styled(BaseDiv)`
   justify-content: center;
   padding-right: 100px;
+
+  &.fa-star: {
+    &:hover: {
+      color: gold;
+    }
+  }
+`;
+
+const StarBtn = styled.button`
+  border: none;
+  background-color: transparent;
+  cursor: pointer;
+  width: fit-content;
+  height: fit-content;
+  margin: 2px;
+  padding: 0px;
 `;
 
 export {
@@ -54,4 +70,5 @@ export {
   CategorySpanDiv,
   CategorySpan,
   StarRateDiv,
+  StarBtn,
 };

--- a/client/src/components/Common/DynamicStarRate/index.tsx
+++ b/client/src/components/Common/DynamicStarRate/index.tsx
@@ -8,20 +8,20 @@ import {
   CategorySpan,
   StarRateDiv,
 } from './index.style';
+import { mouseOverStarHandler } from '@controllers/reviewController';
 
 const DynamicStarRateDiv: React.FC<{ category: string }> = ({ category }) => {
+  const faIconList = Array(5)
+    .fill(1)
+    .map((n) => {
+      return <FontAwesomeIcon key={n} icon={faStar} size="lg" />;
+    });
   return (
     <RateStarDiv>
       <CategorySpanDiv>
         <CategorySpan>{category}</CategorySpan>
       </CategorySpanDiv>
-      <StarRateDiv>
-        <FontAwesomeIcon icon={faStar} size="lg" />
-        <FontAwesomeIcon icon={faStar} size="lg" />
-        <FontAwesomeIcon icon={faStar} size="lg" />
-        <FontAwesomeIcon icon={faStar} size="lg" />
-        <FontAwesomeIcon icon={faStar} size="lg" />
-      </StarRateDiv>
+      <StarRateDiv>{faIconList}</StarRateDiv>
     </RateStarDiv>
   );
 };

--- a/client/src/components/Common/DynamicStarRate/index.tsx
+++ b/client/src/components/Common/DynamicStarRate/index.tsx
@@ -31,7 +31,7 @@ const DynamicStarRateDiv: React.FC<IProps> = ({
   const faIconList = Array.from({ length: 5 }, (_, index) => index + 1).map(
     (n) => {
       return (
-        <StarBtn key={n}>
+        <StarBtn key={category + n}>
           <FontAwesomeIcon
             style={n <= number ? { color: 'gold' } : { color: 'lightgrey' }}
             icon={faStar}

--- a/client/src/components/Common/DynamicStarRate/index.tsx
+++ b/client/src/components/Common/DynamicStarRate/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faStar } from '@fortawesome/free-solid-svg-icons';
 
@@ -9,7 +9,6 @@ import {
   StarRateDiv,
   StarBtn,
 } from './index.style';
-import { mouseOverStarHandler } from '@controllers/reviewController';
 
 interface IProps {
   category: keyof CategoryRateType['categories'];

--- a/client/src/components/Common/DynamicStarRate/index.tsx
+++ b/client/src/components/Common/DynamicStarRate/index.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faStar } from '@fortawesome/free-solid-svg-icons';
+
+import {
+  RateStarDiv,
+  CategorySpanDiv,
+  CategorySpan,
+  StarRateDiv,
+} from './index.style';
+
+const DynamicStarRateDiv: React.FC<{ category: string }> = ({ category }) => {
+  return (
+    <RateStarDiv>
+      <CategorySpanDiv>
+        <CategorySpan>{category}</CategorySpan>
+      </CategorySpanDiv>
+      <StarRateDiv>
+        <FontAwesomeIcon icon={faStar} size="lg" />
+        <FontAwesomeIcon icon={faStar} size="lg" />
+        <FontAwesomeIcon icon={faStar} size="lg" />
+        <FontAwesomeIcon icon={faStar} size="lg" />
+        <FontAwesomeIcon icon={faStar} size="lg" />
+      </StarRateDiv>
+    </RateStarDiv>
+  );
+};
+
+export default DynamicStarRateDiv;

--- a/client/src/components/Common/DynamicStarRate/index.tsx
+++ b/client/src/components/Common/DynamicStarRate/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faStar } from '@fortawesome/free-solid-svg-icons';
 
@@ -7,21 +7,54 @@ import {
   CategorySpanDiv,
   CategorySpan,
   StarRateDiv,
+  StarBtn,
 } from './index.style';
 import { mouseOverStarHandler } from '@controllers/reviewController';
 
-const DynamicStarRateDiv: React.FC<{ category: string }> = ({ category }) => {
-  const faIconList = Array(5)
-    .fill(1)
-    .map((n) => {
-      return <FontAwesomeIcon key={n} icon={faStar} size="lg" />;
-    });
+interface IProps {
+  category: keyof CategoryRateType['categories'];
+  name: string;
+  rate: number;
+  setCategoryRate: (
+    category: keyof CategoryRateType['categories'],
+    rate: number,
+  ) => void;
+}
+
+const DynamicStarRateDiv: React.FC<IProps> = ({
+  category,
+  name,
+  rate,
+  setCategoryRate,
+}) => {
+  const [checkedNumber, setCheckedNumber] = useState(rate);
+  const [number, setNumber] = useState(rate);
+  const faIconList = Array.from({ length: 5 }, (_, index) => index + 1).map(
+    (n) => {
+      return (
+        <StarBtn key={n}>
+          <FontAwesomeIcon
+            style={n <= number ? { color: 'gold' } : { color: 'lightgrey' }}
+            icon={faStar}
+            size="lg"
+            onMouseOver={() => setNumber(n)}
+            onMouseLeave={() => setNumber(checkedNumber)}
+            onClick={() => {
+              setCheckedNumber(n);
+              setCategoryRate(category, n);
+            }}
+          />
+        </StarBtn>
+      );
+    },
+  );
+
   return (
     <RateStarDiv>
       <CategorySpanDiv>
-        <CategorySpan>{category}</CategorySpan>
+        <CategorySpan>{name}</CategorySpan>
       </CategorySpanDiv>
-      <StarRateDiv>{faIconList}</StarRateDiv>
+      <StarRateDiv className="test">{faIconList}</StarRateDiv>
     </RateStarDiv>
   );
 };

--- a/client/src/components/Common/HashTag/index.tsx
+++ b/client/src/components/Common/HashTag/index.tsx
@@ -9,8 +9,8 @@ interface IProps {
 const HashTagList: React.FC<IProps> = ({ hashTags }) => {
   return (
     <>
-      {hashTags.map((hashTag: string) => (
-        <HashTag key={hashTag}>{hashTag}</HashTag>
+      {hashTags.map((hashTag: string, idx) => (
+        <HashTag key={idx}>{hashTag}</HashTag>
       ))}
     </>
   );

--- a/client/src/components/Common/StarRate/index.tsx
+++ b/client/src/components/Common/StarRate/index.tsx
@@ -16,11 +16,11 @@ interface IProps {
 }
 
 const StarRateDiv: React.FC<IProps> = ({ isLarge, total }) => {
-  const faIconList = Array(5)
-    .fill(1)
-    .map((n) => {
+  const faIconList = Array.from({ length: 5 }, (_, index) => index + 1).map(
+    (n) => {
       return <FontAwesomeIcon key={n} icon={faStar} />;
-    });
+    },
+  );
   return (
     <RateNumStarDiv>
       <RateSpanText isLarge={isLarge}>{total}</RateSpanText>

--- a/client/src/components/Common/StarRate/index.tsx
+++ b/client/src/components/Common/StarRate/index.tsx
@@ -16,24 +16,17 @@ interface IProps {
 }
 
 const StarRateDiv: React.FC<IProps> = ({ isLarge, total }) => {
+  const faIconList = Array(5)
+    .fill(1)
+    .map((n) => {
+      return <FontAwesomeIcon key={n} icon={faStar} />;
+    });
   return (
     <RateNumStarDiv>
       <RateSpanText isLarge={isLarge}>{total}</RateSpanText>
       <RateStarDiv>
-        <RateStarFillDiv rate={Number(total)}>
-          <FontAwesomeIcon icon={faStar} />
-          <FontAwesomeIcon icon={faStar} />
-          <FontAwesomeIcon icon={faStar} />
-          <FontAwesomeIcon icon={faStar} />
-          <FontAwesomeIcon icon={faStar} />
-        </RateStarFillDiv>
-        <RateStarBaseDiv>
-          <FontAwesomeIcon icon={faStar} />
-          <FontAwesomeIcon icon={faStar} />
-          <FontAwesomeIcon icon={faStar} />
-          <FontAwesomeIcon icon={faStar} />
-          <FontAwesomeIcon icon={faStar} />
-        </RateStarBaseDiv>
+        <RateStarFillDiv rate={Number(total)}>{faIconList}</RateStarFillDiv>
+        <RateStarBaseDiv>{faIconList}</RateStarBaseDiv>
       </RateStarDiv>
     </RateNumStarDiv>
   );

--- a/client/src/components/Header/index.tsx
+++ b/client/src/components/Header/index.tsx
@@ -19,16 +19,17 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faUserCircle } from '@fortawesome/free-solid-svg-icons';
 
 import React, { useCallback, useEffect, useState } from 'react';
-import { withRouter } from 'react-router-dom';
+import { useHistory, useLocation } from 'react-router-dom';
 import { useRecoilState } from 'recoil';
 
 // export interface MainIProps {
 //   showSidebar(): void;
 //   hideSidebar(): void;
 // }
-
-const Header: React.FC = withRouter(({ history, location }) => {
+const Header: React.FC = () => {
   const [clickedLinkBtnId, setClickedLinkBtnId] = useState('/');
+  const history = useHistory();
+  const location = useLocation();
   const [isAuth, setIsAuth] = useRecoilState(authState);
 
   // const openSideBar = useCallback(() => {
@@ -119,6 +120,6 @@ const Header: React.FC = withRouter(({ history, location }) => {
       <ColorBar></ColorBar>
     </>
   );
-});
+};
 
 export default Header;

--- a/client/src/components/ReviewModal/index.style.tsx
+++ b/client/src/components/ReviewModal/index.style.tsx
@@ -1,0 +1,57 @@
+import styled from 'styled-components';
+
+const BaseDiv = styled.div`
+  position: relative;
+  width: 100%;
+  ${(props) => props.theme.flexRow};
+  justify-content: center;
+`;
+
+const TitleDiv = styled(BaseDiv)`
+  font-size: ${(props) => props.theme.paragraph};
+  text-align: center;
+`;
+
+const StarRateDiv = styled.div`
+  margin-top: 15px;
+  width: 100%;
+  position: relative;
+  ${(props) => props.theme.flexColumn};
+  justify-content: center;
+  align-items: center;
+`;
+
+const TextAreaDiv = styled(BaseDiv)`
+  margin-top: 15px;
+  position: relative;
+  ${(props) => props.theme.flexRow};
+  justify-content: center;
+`;
+
+const TextInput = styled.textarea`
+  display: block;
+  width: 70%;
+  height: 100px;
+  margin: auto;
+  padding: 0 30px 50px 0px;
+  border: 1px solid ${(props) => props.theme.colors.lightgrey};
+  resize: none;
+  line-height: 24px;
+`;
+
+const SubmitDiv = styled(BaseDiv)`
+  margin-top: 15px;
+`;
+
+const SubmitBtn = styled.button`
+  display: block;
+  margin: auto;
+  width: 70%;
+  padding: 10px 0px;
+  border: none;
+  color: ${(props) => props.theme.colors.white};
+  background-color: ${(props) => props.theme.colors.lightgreen};
+  cursor: pointer;
+`;
+
+export { TitleDiv, StarRateDiv, TextAreaDiv, TextInput, SubmitDiv, SubmitBtn };

--- a/client/src/components/ReviewModal/index.tsx
+++ b/client/src/components/ReviewModal/index.tsx
@@ -26,10 +26,10 @@ const ReviewModal: React.FC = () => {
     address: DEFAULT_ADDRESS,
     content: '',
     categories: {
-      safety: 0,
-      traffic: 0,
-      food: 0,
-      entertainment: 0,
+      safety: 1,
+      traffic: 1,
+      food: 1,
+      entertainment: 1,
     },
   });
 
@@ -39,21 +39,36 @@ const ReviewModal: React.FC = () => {
     });
   }, []);
 
-  const RatingStars = (Object.keys(Category) as (keyof typeof Category)[]).map(
-    (category, idx) => {
-      return (
-        <DynamicStarRateDiv
-          key={idx}
-          category={Category[category]}
-        ></DynamicStarRateDiv>
-      );
+  const setCategoryRate = useCallback(
+    (category: keyof CategoryRateType['categories'], rate: number) => {
+      setReviewData((prevData) => {
+        return {
+          ...prevData,
+          categories: { ...prevData.categories, [category]: rate },
+        };
+      });
     },
+    [],
   );
 
   const submitHandler = (e) => {
     e.preventDefault();
     submitReview(reviewData);
   };
+
+  const RatingStars = (Object.keys(Category) as (keyof typeof Category)[]).map(
+    (category) => {
+      return (
+        <DynamicStarRateDiv
+          key={category}
+          category={category}
+          name={Category[category]}
+          rate={reviewData.categories[category]}
+          setCategoryRate={setCategoryRate}
+        ></DynamicStarRateDiv>
+      );
+    },
+  );
 
   return (
     <Modal>

--- a/client/src/components/ReviewModal/index.tsx
+++ b/client/src/components/ReviewModal/index.tsx
@@ -35,7 +35,7 @@ const ReviewModal: React.FC<ReviewType> = ({ address, text, categories }) => {
 
   const setText = useCallback((text: string) => {
     setReviewData((prevData) => {
-      return { ...prevData, content: text.slice(0, 400) };
+      return { ...prevData, text: text.slice(0, 400) };
     });
   }, []);
 

--- a/client/src/components/ReviewModal/index.tsx
+++ b/client/src/components/ReviewModal/index.tsx
@@ -1,0 +1,68 @@
+import React, { useCallback, useState } from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faMapMarkerAlt } from '@fortawesome/free-solid-svg-icons';
+
+import Modal from '@components/modal';
+import {
+  TitleDiv,
+  StarRateDiv,
+  TextAreaDiv,
+  TextInput,
+  SubmitDiv,
+  SubmitBtn,
+} from './index.style';
+import DynamicStarRateDiv from '@components/Common/DynamicStarRate';
+import { Category } from '@utils/enum';
+
+const ReviewModal: React.FC = () => {
+  const [content, setContent] = useState('');
+
+  const RatingStars = (Object.keys(Category) as (keyof typeof Category)[]).map(
+    (category, idx) => {
+      return (
+        <DynamicStarRateDiv
+          key={idx}
+          category={Category[category]}
+        ></DynamicStarRateDiv>
+      );
+    },
+  );
+
+  const setText = useCallback((text: string) => {
+    setContent(text.slice(0, 400));
+  }, []);
+
+  return (
+    <Modal>
+      <TitleDiv>
+        <FontAwesomeIcon icon={faMapMarkerAlt}></FontAwesomeIcon>
+        <span style={{ marginLeft: '10px' }}>경기도 성남시 분당구 판교동</span>
+      </TitleDiv>
+      <StarRateDiv>{RatingStars}</StarRateDiv>
+      <TextAreaDiv>
+        <TextInput
+          placeholder="후기를 작성해주세요.(선택, 400자 이내)"
+          rows={3}
+          cols={20}
+          onChange={(e) => setText(e.target.value)}
+          value={content}
+        ></TextInput>
+        <p
+          style={{
+            position: 'absolute',
+            right: '75px',
+            bottom: '-10px',
+            color: 'red',
+          }}
+        >
+          {content.length} / 400
+        </p>
+      </TextAreaDiv>
+      <SubmitDiv>
+        <SubmitBtn>제출하기</SubmitBtn>
+      </SubmitDiv>
+    </Modal>
+  );
+};
+
+export default ReviewModal;

--- a/client/src/components/ReviewModal/index.tsx
+++ b/client/src/components/ReviewModal/index.tsx
@@ -17,18 +17,14 @@ import { submitReview } from '@controllers/reviewController';
 
 interface ReviewType extends CategoryRateType {
   address: string;
-  content: string;
+  text: string;
 }
 
-const ReviewModal: React.FC<ReviewType> = ({
-  address,
-  content,
-  categories,
-}) => {
+const ReviewModal: React.FC<ReviewType> = ({ address, text, categories }) => {
   const DEFAULT_ADDRESS = address || '대전시 서구 탄방동';
   const [reviewData, setReviewData] = useState<ReviewType>({
     address: DEFAULT_ADDRESS,
-    content: content || '',
+    text: text || '',
     categories: categories || {
       safety: 1,
       traffic: 1,
@@ -87,7 +83,7 @@ const ReviewModal: React.FC<ReviewType> = ({
           rows={3}
           cols={20}
           onChange={(e) => setText(e.target.value)}
-          value={reviewData.content}
+          value={reviewData.text}
         ></TextInput>
         <p
           style={{
@@ -97,7 +93,7 @@ const ReviewModal: React.FC<ReviewType> = ({
             color: 'red',
           }}
         >
-          {reviewData.content.length} / 400
+          {reviewData.text.length} / 400
         </p>
       </TextAreaDiv>
       <SubmitDiv>

--- a/client/src/components/ReviewModal/index.tsx
+++ b/client/src/components/ReviewModal/index.tsx
@@ -13,9 +13,31 @@ import {
 } from './index.style';
 import DynamicStarRateDiv from '@components/Common/DynamicStarRate';
 import { Category } from '@utils/enum';
+import { submitReview } from '@controllers/reviewController';
+
+interface ReviewType extends CategoryRateType {
+  address: string;
+  content: string;
+}
 
 const ReviewModal: React.FC = () => {
-  const [content, setContent] = useState('');
+  const DEFAULT_ADDRESS = '대전시 서구 탄방동';
+  const [reviewData, setReviewData] = useState<ReviewType>({
+    address: DEFAULT_ADDRESS,
+    content: '',
+    categories: {
+      safety: 0,
+      traffic: 0,
+      food: 0,
+      entertainment: 0,
+    },
+  });
+
+  const setText = useCallback((text: string) => {
+    setReviewData((prevData) => {
+      return { ...prevData, content: text.slice(0, 400) };
+    });
+  }, []);
 
   const RatingStars = (Object.keys(Category) as (keyof typeof Category)[]).map(
     (category, idx) => {
@@ -28,15 +50,16 @@ const ReviewModal: React.FC = () => {
     },
   );
 
-  const setText = useCallback((text: string) => {
-    setContent(text.slice(0, 400));
-  }, []);
+  const submitHandler = (e) => {
+    e.preventDefault();
+    submitReview(reviewData);
+  };
 
   return (
     <Modal>
       <TitleDiv>
         <FontAwesomeIcon icon={faMapMarkerAlt}></FontAwesomeIcon>
-        <span style={{ marginLeft: '10px' }}>경기도 성남시 분당구 판교동</span>
+        <span style={{ marginLeft: '10px' }}>{DEFAULT_ADDRESS}</span>
       </TitleDiv>
       <StarRateDiv>{RatingStars}</StarRateDiv>
       <TextAreaDiv>
@@ -45,7 +68,7 @@ const ReviewModal: React.FC = () => {
           rows={3}
           cols={20}
           onChange={(e) => setText(e.target.value)}
-          value={content}
+          value={reviewData.content}
         ></TextInput>
         <p
           style={{
@@ -55,11 +78,11 @@ const ReviewModal: React.FC = () => {
             color: 'red',
           }}
         >
-          {content.length} / 400
+          {reviewData.content.length} / 400
         </p>
       </TextAreaDiv>
       <SubmitDiv>
-        <SubmitBtn>제출하기</SubmitBtn>
+        <SubmitBtn onClick={submitHandler}>제출하기</SubmitBtn>
       </SubmitDiv>
     </Modal>
   );

--- a/client/src/components/ReviewModal/index.tsx
+++ b/client/src/components/ReviewModal/index.tsx
@@ -20,12 +20,16 @@ interface ReviewType extends CategoryRateType {
   content: string;
 }
 
-const ReviewModal: React.FC = () => {
-  const DEFAULT_ADDRESS = '대전시 서구 탄방동';
+const ReviewModal: React.FC<ReviewType> = ({
+  address,
+  content,
+  categories,
+}) => {
+  const DEFAULT_ADDRESS = address || '대전시 서구 탄방동';
   const [reviewData, setReviewData] = useState<ReviewType>({
     address: DEFAULT_ADDRESS,
-    content: '',
-    categories: {
+    content: content || '',
+    categories: categories || {
       safety: 1,
       traffic: 1,
       food: 1,

--- a/client/src/components/Searchbar/index.style.tsx
+++ b/client/src/components/Searchbar/index.style.tsx
@@ -15,7 +15,7 @@ const SearchbarWrapper = styled.div`
   background: #fff;
   border: solid 2px #33ab74;
   border-radius: 20px;
-  z-index: 50;
+  z-index: 1000;
 `;
 
 const SearchbarInput = styled.input`
@@ -48,7 +48,7 @@ const DropdownWrapper = styled.div`
   background: #fff;
   border-radius: 10px;
   border: solid 1px #c5c5c5;
-  z-index: 50;
+  z-index: 1000;
   max-height: 600px;
   overflow-x: hidden;
   overflow-y: scroll;

--- a/client/src/components/Searchbar/index.style.tsx
+++ b/client/src/components/Searchbar/index.style.tsx
@@ -15,7 +15,7 @@ const SearchbarWrapper = styled.div`
   background: #fff;
   border: solid 2px #33ab74;
   border-radius: 20px;
-  z-index: 1000;
+  z-index: 50;
 `;
 
 const SearchbarInput = styled.input`
@@ -48,7 +48,7 @@ const DropdownWrapper = styled.div`
   background: #fff;
   border-radius: 10px;
   border: solid 1px #c5c5c5;
-  z-index: 1000;
+  z-index: 50;
   max-height: 600px;
   overflow-x: hidden;
   overflow-y: scroll;

--- a/client/src/components/Sidebar/index.tsx
+++ b/client/src/components/Sidebar/index.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useHistory, useLocation } from 'react-router-dom';
 
 import {
   Container,
@@ -35,6 +36,8 @@ export interface RateProps {
 
 const Sidebar: React.FC<RateProps> = (props: RateProps) => {
   const [selectedMenu, setSelectedMenu] = useState('review');
+  const history = useHistory();
+  const location = useLocation();
   const fetchData = (menu: string) => {
     console.log(menu);
     setSelectedMenu(menu);
@@ -95,7 +98,16 @@ const Sidebar: React.FC<RateProps> = (props: RateProps) => {
           </ContentDiv>
         ))}
         <AddButtonDiv>
-          <AddButton>내 동네 후기 작성하기</AddButton>
+          <AddButton
+            onClick={() => {
+              history.push({
+                pathname: '/write-review',
+                state: { background: location },
+              });
+            }}
+          >
+            내 동네 후기 작성하기
+          </AddButton>
         </AddButtonDiv>
       </Layout>
     </Container>

--- a/client/src/components/modal/index.style.tsx
+++ b/client/src/components/modal/index.style.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-export const ModalOverlay = styled.div`
+const ModalOverlay = styled.div`
   position: fixed;
   top: 0;
   left: 0;
@@ -11,7 +11,7 @@ export const ModalOverlay = styled.div`
   z-index: 99;
 `;
 
-export const ModalWrapper = styled.div`
+const ModalWrapper = styled.div`
   position: absolute;
   max-width: 80%;
   width: auto;
@@ -31,3 +31,17 @@ export const ModalWrapper = styled.div`
 
   z-index: 100;
 `;
+
+const ModalCloseBtnDiv = styled.div`
+  ${(props) => props.theme.common.flexRow};
+  justify-content: flex-end;
+  width: 100%;
+`;
+
+const ModalCloseBtn = styled.button`
+  border: none;
+  background-color: transparent;
+  cursor: pointer;
+`;
+
+export { ModalOverlay, ModalWrapper, ModalCloseBtnDiv, ModalCloseBtn };

--- a/client/src/components/modal/index.style.tsx
+++ b/client/src/components/modal/index.style.tsx
@@ -14,7 +14,7 @@ const ModalOverlay = styled.div`
 const ModalWrapper = styled.div`
   position: absolute;
   max-width: 80%;
-  width: auto;
+  width: 500px;
   max-height: 80%;
   height: auto;
   top: 50%;

--- a/client/src/components/modal/index.style.tsx
+++ b/client/src/components/modal/index.style.tsx
@@ -8,7 +8,7 @@ const ModalOverlay = styled.div`
   right: 0;
   background-color: rgba(0, 0, 0, 0.4);
 
-  z-index: 99;
+  z-index: 3000;
 `;
 
 const ModalWrapper = styled.div`
@@ -19,6 +19,7 @@ const ModalWrapper = styled.div`
   height: auto;
   top: 50%;
   left: 50%;
+  overflow: auto;
   transform: translate(-50%, -50%);
   ${(props) => props.theme.common.flexColumn};
   justify-content: space-between;
@@ -29,7 +30,7 @@ const ModalWrapper = styled.div`
   border-radius: 10px;
   background-color: ${(props) => props.theme.colors.white};
 
-  z-index: 100;
+  z-index: 3000;
 `;
 
 const ModalCloseBtnDiv = styled.div`

--- a/client/src/components/modal/index.tsx
+++ b/client/src/components/modal/index.tsx
@@ -4,7 +4,6 @@ import {
   ModalCloseBtnDiv,
   ModalCloseBtn,
 } from './index.style';
-import closeButton from '@assets/closeButton.png';
 
 import React, { useState, useEffect, useRef } from 'react';
 import { useHistory } from 'react-router-dom';

--- a/client/src/components/modal/index.tsx
+++ b/client/src/components/modal/index.tsx
@@ -1,4 +1,9 @@
-import { ModalOverlay, ModalWrapper } from './index.style';
+import {
+  ModalOverlay,
+  ModalWrapper,
+  ModalCloseBtnDiv,
+  ModalCloseBtn,
+} from './index.style';
 import closeButton from '@assets/closeButton.png';
 
 import React, { useState, useEffect, useRef } from 'react';
@@ -53,7 +58,9 @@ const Modal: React.FC = ({ children }) => {
       {isActive && (
         <ModalOverlay>
           <ModalWrapper ref={modalRef}>
-            <img src={closeButton} alt="모달창닫기" onClick={onClick}></img>
+            <ModalCloseBtnDiv>
+              <ModalCloseBtn onClick={onClick}>✖</ModalCloseBtn>
+            </ModalCloseBtnDiv>
             {children}
           </ModalWrapper>
         </ModalOverlay>

--- a/client/src/components/modal/index.tsx
+++ b/client/src/components/modal/index.tsx
@@ -35,6 +35,12 @@ const Modal: React.FC = ({ children }) => {
   useEffect(() => {
     const handleCloseModal = (e) => {
       if (
+        !e.target.closest('.overlay-confirmation-submit') &&
+        e.target.closest('.overlay-confirmation-alert')
+      ) {
+        return;
+      }
+      if (
         isActive &&
         (!modalRef.current || !modalRef.current.contains(e.target))
       ) {

--- a/client/src/controllers/reviewController.ts
+++ b/client/src/controllers/reviewController.ts
@@ -1,0 +1,14 @@
+const mouseOverStarHandler = (e) => {
+  const data = e.target.dataset.value;
+};
+
+interface ReviewDataType {
+  address: string;
+  content: string;
+}
+
+const submitReview = (data: ReviewDataType) => {
+  console.log(data.address, data.content);
+};
+
+export { mouseOverStarHandler, submitReview };

--- a/client/src/controllers/reviewController.ts
+++ b/client/src/controllers/reviewController.ts
@@ -8,7 +8,7 @@ interface ReviewDataType {
 }
 
 const submitReview = (data: ReviewDataType) => {
-  console.log(data.address, data.content);
+  console.log(data);
 };
 
 export { mouseOverStarHandler, submitReview };

--- a/client/src/controllers/reviewController.ts
+++ b/client/src/controllers/reviewController.ts
@@ -1,7 +1,3 @@
-const mouseOverStarHandler = (e) => {
-  const data = e.target.dataset.value;
-};
-
 interface ReviewDataType {
   address: string;
   content: string;
@@ -11,4 +7,4 @@ const submitReview = (data: ReviewDataType) => {
   console.log(data);
 };
 
-export { mouseOverStarHandler, submitReview };
+export { submitReview };

--- a/client/src/controllers/reviewController.ts
+++ b/client/src/controllers/reviewController.ts
@@ -13,8 +13,16 @@ const submitReview = (data: ReviewDataType) => {
       {
         label: '제출',
         className: 'overlay-confirmation-submit',
-        onClick: () => {
-          console.log(data);
+        onClick: async () => {
+          fetch(`${process.env.REACT_APP_API_URL}/review`, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify(data),
+          })
+            .then((res) => res.json())
+            .then((res) => console.log(res));
         },
       },
       {

--- a/client/src/controllers/reviewController.ts
+++ b/client/src/controllers/reviewController.ts
@@ -1,10 +1,34 @@
+import { confirmAlert } from 'react-confirm-alert';
+import 'react-confirm-alert/src/react-confirm-alert.css';
+
 interface ReviewDataType {
   address: string;
   content: string;
 }
 
 const submitReview = (data: ReviewDataType) => {
-  console.log(data);
+  confirmAlert({
+    message: '후기를 제출하시겠습니까?',
+    buttons: [
+      {
+        label: '제출',
+        className: 'overlay-confirmation-submit',
+        onClick: () => {
+          console.log(data);
+        },
+      },
+      {
+        label: '취소',
+        className: 'overlay-confirmation-cancel',
+        onClick: () => {
+          return;
+        },
+      },
+    ],
+    closeOnEscape: false,
+    closeOnClickOutside: false,
+    overlayClassName: 'overlay-confirmation-alert',
+  });
 };
 
 export { submitReview };

--- a/client/src/controllers/reviewController.ts
+++ b/client/src/controllers/reviewController.ts
@@ -3,7 +3,7 @@ import 'react-confirm-alert/src/react-confirm-alert.css';
 
 interface ReviewDataType {
   address: string;
-  content: string;
+  text: string;
 }
 
 const submitReview = (data: ReviewDataType) => {

--- a/client/src/pages/MainPage.tsx
+++ b/client/src/pages/MainPage.tsx
@@ -20,28 +20,16 @@ const FlexContainer = styled.div`
 `;
 
 // Rate, Review 는 Backend에서 아래와 같은 형식으로 반환한다고 가정
-export interface RateType {
+export interface RateType extends CategoryRateType {
   address: string;
   code: string;
   codeLength: number;
   center: [number, number];
   total: number;
   count: number;
-  categories: {
-    safety: number;
-    traffic: number;
-    food: number;
-    entertainment: number;
-  };
 }
 
-export interface ReviewType {
-  categories: {
-    safety: number;
-    traffic: number;
-    food: number;
-    entertainment: number;
-  };
+export interface ReviewType extends CategoryRateType {
   text: string;
   user: string;
 }

--- a/client/src/utils/enum.ts
+++ b/client/src/utils/enum.ts
@@ -1,0 +1,8 @@
+enum Category {
+  safety = '치안',
+  traffic = '교통',
+  food = '음식',
+  entertainment = '놀거리',
+}
+
+export { Category };

--- a/client/src/utils/type.d.ts
+++ b/client/src/utils/type.d.ts
@@ -1,0 +1,2 @@
+declare global {}
+export {};

--- a/client/src/utils/type.d.ts
+++ b/client/src/utils/type.d.ts
@@ -1,2 +1,11 @@
-declare global {}
+declare global {
+  interface CategoryRateType {
+    categories: {
+      safety: number;
+      traffic: number;
+      food: number;
+      entertainment: number;
+    };
+  }
+}
 export {};

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -9450,6 +9450,11 @@ react-app-polyfill@^2.0.0:
     regenerator-runtime "^0.13.7"
     whatwg-fetch "^3.4.1"
 
+react-confirm-alert@^2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/react-confirm-alert/-/react-confirm-alert-2.7.0.tgz#7cdbf2e052e03554ac6a7d8956c9c227010c8a53"
+  integrity sha512-21NWtGK/e85+ZX3TLRpMc3IsU5Kj6Z9ElCOrkTIlwMzV9EancyXNlkqHGbtKP63a2iS6g5hOxROokmJOqKQiXA==
+
 react-dev-utils@^11.0.3:
   version "11.0.4"
   resolved "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-11.0.4.tgz"


### PR DESCRIPTION
### 🔨 작업 내용 설명
- 후기 작성 버튼 클릭 시 해당 Modal UI 구현

### 📑 구현한 내용
- 후기 작성 Modal UI React Router로 Routing 되도록 구현
- 후기 작성 Modal UI 전체 구현
- 후기 작성 Modal 내 Star Rating 마우스 이벤트 기능 구현
- FontAwesome Star 코드 부분 List 형태로 반복문 구현으로 Refactoring
  - Key 값이 유일값이 되도록 조정
- Category의 Type과 Enum을 전체에서 사용할 수 있도록 utils 에 추가(전체 코드에서 사용 가능)
  - Type이 겹치는 것은 해당 type을 extend하여 사용
- withRouter 부분을 useHistory, useLocation hook을 사용하도록 변경(crong 님 의견)
- 후기 작성 후 제출 시, Confirmation Alert 발생, 취소 버튼 시 Modal 닫히는 오류 해소를 위한 Modal handleClose 로직 추가

### 🚧 주의 사항
- 별표 이벤트 구현을 위해 상태를 부모에서 관리하는데 이에 대한 적용이 조금 어려웠습니다.
- Type/Enum을 utils에 적용해서 앞으로는 공통으로 사용되는 내용은 해당 파일에 정리하면 모든 곳에서 공통으로 사용 가능합니다.

### 스크린 샷
![image](https://user-images.githubusercontent.com/31230442/141325955-c383a829-cf72-435b-839b-6699639a7e50.png)

위 별표에 최저점 1점으로 기본 설정되며, 이후 마우스 이동, 클릭 시의 상태를 관리하여 값을 전달할 수 있도록 설정했습니다.

closes #75 
