### PR TITLE
[Feat] 폴리곤 클릭시 해당 지역 사이드바 열기

### DIFF
--- a/client/src/components/Map/index.tsx
+++ b/client/src/components/Map/index.tsx
@@ -16,7 +16,7 @@ import {
   displayMarkers,
   deleteMarkers,
   createMarkerClickListener,
-  requestRates,
+  LFURates,
 } from '@controllers/markerController';
 
 import './markerStyle.css';
@@ -44,7 +44,8 @@ const MapComponent: React.FC<IProps> = ({
 }) => {
   const mapWrapper = useRef<HTMLDivElement | null>(null);
   const [map, setMap] = useState<kakao.maps.Map | null>(null);
-  const cache = useRef(new Map());
+  const polygonCache = useRef(new Map());
+  const markerCache = useRef(new Map());
 
   const [position, setPosition] = useState(DEFAULT_POSITION);
   const [range, setRange] = useState({
@@ -133,7 +134,7 @@ const MapComponent: React.FC<IProps> = ({
   useEffect(() => {
     const { scale, region } = range;
     const updatePolygons = async () => {
-      const regions = await LFURegions(cache.current, scale, region);
+      const regions = await LFURegions(polygonCache.current, scale, region);
       const polygons = createPolygons(regions);
       setPolygons(polygons);
     };
@@ -150,8 +151,12 @@ const MapComponent: React.FC<IProps> = ({
   useEffect(() => {
     const { scale, region } = range;
     const updateMarkers = async () => {
-      const markerInfos = await requestRates(scale, region);
-      const markers = createMarkers(markerInfos);
+      const rates = (await LFURates(
+        markerCache.current,
+        scale,
+        region,
+      )) as RateType[];
+      const markers = createMarkers(rates);
       setMarkers(markers);
     };
     updateMarkers();

--- a/client/src/components/Map/index.tsx
+++ b/client/src/components/Map/index.tsx
@@ -15,8 +15,8 @@ import {
   createMarkers,
   displayMarkers,
   deleteMarkers,
-  regionToMarkerInfo,
   createMarkerClickListener,
+  requestRates,
 } from '@controllers/markerController';
 
 import './markerStyle.css';
@@ -134,13 +134,8 @@ const MapComponent: React.FC<IProps> = ({
     const { scale, region } = range;
     const updatePolygons = async () => {
       const regions = await LFURegions(cache.current, scale, region);
-      console.log(regions);
       const polygons = createPolygons(regions);
       setPolygons(polygons);
-
-      const markerInfos = regions.map((region) => regionToMarkerInfo(region));
-      const markers = createMarkers(markerInfos);
-      setMarkers(markers);
     };
     updatePolygons();
   }, [range]);
@@ -151,6 +146,16 @@ const MapComponent: React.FC<IProps> = ({
     displayPolygons(polygons, map);
     return () => deletePolygons(polygons);
   }, [map, polygons]);
+
+  useEffect(() => {
+    const { scale, region } = range;
+    const updateMarkers = async () => {
+      const markerInfos = await requestRates(scale, region);
+      const markers = createMarkers(markerInfos);
+      setMarkers(markers);
+    };
+    updateMarkers();
+  }, [range]);
 
   useEffect(() => {
     if (!map) return;

--- a/client/src/components/Map/index.tsx
+++ b/client/src/components/Map/index.tsx
@@ -9,6 +9,9 @@ import {
   displayPolygons,
   deletePolygons,
   LFURegions,
+  addPolygonClickEvent,
+  removePolygonClickEvent,
+  RegionPolygon,
 } from '@controllers/mapController';
 
 import {
@@ -17,6 +20,7 @@ import {
   deleteMarkers,
   createMarkerClickListener,
   LFURates,
+  findMarker,
 } from '@controllers/markerController';
 
 import './markerStyle.css';
@@ -54,7 +58,7 @@ const MapComponent: React.FC<IProps> = ({
   });
 
   const [markers, setMarkers] = useState(Array<kakao.maps.CustomOverlay>());
-  const [polygons, setPolygons] = useState(Array<kakao.maps.Polygon>());
+  const [polygons, setPolygons] = useState(Array<RegionPolygon>());
 
   useEffect(() => {
     if (!mapWrapper.current) {
@@ -168,6 +172,29 @@ const MapComponent: React.FC<IProps> = ({
     displayMarkers(markers, map);
     return () => deleteMarkers(markers);
   }, [map, markers]);
+
+  useEffect(() => {
+    polygons.forEach((polygon) => {
+      const onClick = () => {
+        kakao.maps.event.preventMap();
+        const matchingMarker = findMarker(markers, polygon.address);
+        if (!matchingMarker) return;
+
+        const markerEl = matchingMarker.getContent() as HTMLElement;
+        const sidebarRate = JSON.parse(markerEl.dataset.rateData as string);
+
+        updateSidebarRate(sidebarRate);
+        openSidebar();
+      };
+      addPolygonClickEvent(polygon, onClick);
+    });
+
+    return () => {
+      polygons.forEach((polygon) => {
+        removePolygonClickEvent(polygon);
+      });
+    };
+  }, [polygons, markers, openSidebar, updateSidebarRate]);
 
   return (
     <MapWrapper ref={mapWrapper}>

--- a/client/src/controllers/mapController.ts
+++ b/client/src/controllers/mapController.ts
@@ -1,7 +1,6 @@
 import ColorHash from 'color-hash';
 
 function getCurrentLocation(callback: (coord: [number, number]) => void) {
-  // const coord: [number, number] = [37.5642135, 127.0016985];
   let coord: [number, number] = [37.5642135, 127.0016985];
 
   const successCallback: PositionCallback = (position) => {

--- a/client/src/controllers/markerController.ts
+++ b/client/src/controllers/markerController.ts
@@ -1,4 +1,3 @@
-import { regionToScaled } from '@utils/address';
 import { RateType } from '@pages/MainPage';
 
 const ratingToPercent = (rate: number) => {
@@ -82,15 +81,11 @@ const random = (from: number, to: number) => {
   return Number((Math.random() * (to - from) + from).toFixed(2));
 };
 
-const getRandomLatLng = () => {
-  return [random(33, 38), random(124, 132)];
-};
-
 const getRandomRate = () => {
   return random(1, 5);
 };
 
-const regionToMarkerInfo = (region): RateType => {
+const regionToRates = (region): RateType => {
   const count = random(0, 100);
   const safety = getRandomRate() * count;
   const traffic = getRandomRate() * count;
@@ -114,28 +109,15 @@ const regionToMarkerInfo = (region): RateType => {
 };
 
 // TODO: fetch 요청
-const requestMarkerInfo = async (
+const requestRates = async (
   scale: number,
   region: string[],
 ): Promise<RateType[]> => {
-  return Array(100)
-    .fill(0)
-    .map(() => {
-      return {
-        address: regionToScaled(region, scale),
-        code: '',
-        codeLength: 0,
-        center: getRandomLatLng() as [number, number],
-        total: 0,
-        count: 0,
-        categories: {
-          safety: getRandomRate(),
-          traffic: getRandomRate(),
-          food: getRandomRate(),
-          entertainment: getRandomRate(),
-        },
-      };
-    });
+  return await fetch(
+    `${process.env.REACT_APP_API_URL}/api/map/rates?scale=${scale}&big=${region[0]}&medium=${region[1]}&small=${region[2]}`,
+  )
+    .then((response) => response.json())
+    .catch((err) => console.error(err));
 };
 
 const createMarkers = (rateDatas: RateType[]): kakao.maps.CustomOverlay[] => {
@@ -198,10 +180,10 @@ const createMarkerClickListener = (
 };
 
 export {
-  requestMarkerInfo,
+  requestRates,
   createMarkers,
   displayMarkers,
   deleteMarkers,
-  regionToMarkerInfo,
+  regionToRates,
   createMarkerClickListener,
 };

--- a/server/ecosystem.config.js
+++ b/server/ecosystem.config.js
@@ -1,4 +1,4 @@
-exports.modules = {
+module.exports = {
   apps: [
     {
       name: 'App', // pm2로 실행한 프로세스 목록에서 이 애플리케이션의 이름으로 지정될 문자열

--- a/server/src/api/adminController.ts
+++ b/server/src/api/adminController.ts
@@ -21,4 +21,14 @@ router.post('/map-data', (req: MapRequest, res: Response) => {
   }
 });
 
+router.post('/rates', (req: MapRequest, res) => {
+  const { password } = req.body;
+  if (password === process.env.ADMIN_PASSWORD) {
+    void updateMapService.populateMapInfos();
+    res.status(200).send('HAHAHA!');
+  } else {
+    res.status(404).send('FXXK! 404 NOT FOUND.... GET OFF!');
+  }
+});
+
 export default router;

--- a/server/src/api/adminController.ts
+++ b/server/src/api/adminController.ts
@@ -27,7 +27,7 @@ router.post('/rates', (req: MapRequest, res) => {
     void updateMapService.populateMapInfos();
     res.status(200).send('HAHAHA!');
   } else {
-    res.status(404).send('FXXK! 404 NOT FOUND.... GET OFF!');
+    res.status(404).send('Sorry.. 404 NOT FOUND.... Good bye!');
   }
 });
 

--- a/server/src/api/mapController.ts
+++ b/server/src/api/mapController.ts
@@ -21,6 +21,36 @@ router.get('/polygon', (async (req: Request, res: Response) => {
   }
 }) as RequestHandler);
 
+router.get('/rates', (async (req, res) => {
+  const { scale, big, medium, small } = req.query;
+  if (scale && (big || medium || small)) {
+    const rates = await mapService.queryRates(
+      Number(scale),
+      big as string,
+      medium as string,
+      small as string,
+    );
+    res.json(rates);
+  } else {
+    res.json([
+      {
+        address: '',
+        code: '',
+        codeLength: 0,
+        center: [],
+        total: 0,
+        count: 0,
+        categories: {
+          safety: 0,
+          traffic: 0,
+          food: 0,
+          entertainment: 0,
+        },
+      },
+    ]);
+  }
+}) as RequestHandler);
+
 router.get('/search', (async (req: Request, res: Response) => {
   const { keyword } = req.query;
   if (typeof keyword === 'string' && keyword.length > 0) {

--- a/server/src/services/mapService.ts
+++ b/server/src/services/mapService.ts
@@ -49,6 +49,7 @@ const queryRates = async (
 ) => {
   let result: MapInfo[] = [];
   const fields = {
+    _id: 0,
     address: 1,
     code: 1,
     codeLength: 1,

--- a/server/src/services/mapService.ts
+++ b/server/src/services/mapService.ts
@@ -41,4 +41,57 @@ const queryCenter = async (keyword: string): Promise<MapInfo[]> => {
   return await MapInfoModel.find({ address: { $regex: RegExp(keyword, 'g') } });
 };
 
-export default { queryPolygon, queryCenter };
+const queryRates = async (
+  scale: number,
+  big: string,
+  medium: string,
+  small: string,
+) => {
+  let result: MapInfo[] = [];
+  const fields = {
+    address: 1,
+    code: 1,
+    codeLength: 1,
+    center: 1,
+    total: '$rate.total',
+    count: '$rate.count',
+    categories: {
+      safety: '$rate.safety',
+      traffic: '$rate.traffic',
+      food: '$rate.food',
+      entertainment: '$rate.entertainment',
+    },
+  };
+
+  switch (true) {
+    case scale < 9:
+      result = await MapInfoModel.find(
+        {
+          $text: { $search: `"${big} ${medium}"` },
+          codeLength: 7,
+        },
+        fields,
+      );
+      break;
+    case 9 <= scale && scale < 12:
+      result = await MapInfoModel.find(
+        {
+          $text: { $search: `${big}` },
+          codeLength: 5,
+        },
+        fields,
+      );
+      break;
+    case 12 <= scale:
+      result = await MapInfoModel.find(
+        {
+          codeLength: 2,
+        },
+        fields,
+      );
+      break;
+  }
+  return result;
+};
+
+export default { queryPolygon, queryCenter, queryRates };

--- a/server/src/services/updateMapService.ts
+++ b/server/src/services/updateMapService.ts
@@ -182,4 +182,34 @@ const populateMapAndSimpleMap = async (): Promise<void> => {
   await recursiveGetCoords('', accessToken);
 };
 
-export default { populateMapAndSimpleMap };
+const random = (from: number, to: number) => {
+  return Number((Math.random() * (to - from) + from).toFixed(2));
+};
+
+const getRandomRate = () => {
+  return random(1, 5);
+};
+
+const populateMapInfos = async () => {
+  (await MapInfoModel.find({})).forEach((doc) => {
+    const count = Math.floor(random(0, 100));
+    const safety = Math.floor(getRandomRate() * count);
+    const traffic = Math.floor(getRandomRate() * count);
+    const food = Math.floor(getRandomRate() * count);
+    const entertainment = Math.floor(getRandomRate() * count);
+    const total = (safety + traffic + food + entertainment) / 4;
+    const rate = {
+      count,
+      total,
+      safety,
+      traffic,
+      food,
+      entertainment,
+    };
+    void doc.updateOne({ rate: rate }, {}, (err, result) => {
+      if (err) logger.error(`Update failed for ${doc.address}`);
+    });
+  });
+};
+
+export default { populateMapAndSimpleMap, populateMapInfos };


### PR DESCRIPTION
### 🔨 작업 내용 설명
- 폴리곤을 클릭하면 사이드바가 열리는 기능
- GitHub Actions 실패 원인 해결

### 📑 구현한 내용
- 기존에 `kakao.maps.Polygon` 타입으로 사용하고있던 폴리곤 객체를 확장하여 `{ address, onClick() }` 프로퍼티를 추가로 가지도록 타입을 확장 => `type RegionPolygon`
- Polygon을 생성할 때 자신이 포함된 지역의 주소(`address`)를 프로퍼티에 추가하여 평점 정보 검색시 사용
- `useEffect` 훅을 이용하여 폴리곤에 이벤트 리스너 등록(`kakao.maps.event.addListener`)
  - 폴리곤이 클릭되면 기존에 상태로 관리되던 `markers` 배열에서 같은 주소(`address`)를 가지고 있는 마커를 탐색(마커의 `content`는 DOM Element로, `dataset`에 주소(`address`)와 평점 정보를 가지고 있음)
  - 해당하는 마커의 `dataset`으로부터 평점 정보를 불러와 사이드바 업데이트 및 열기
- 사이드바가 열려있을 때 폴리곤 클릭시 사이드바가 닫히지 않도록 구현
- `ecosystem.config.js` 오타 `exports.modules = { ` => `module.exports = {` 수정

### 🚧 주의 사항
- `new kakao.maps.LatLng(...center)`의 문제점
  - 처음에는 주소가 아니라 지역 중심좌표를 기준으로 탐색을 하려 하였으나 다음과 같은 이상한 현상이 있음
  ```
  const center: [number, number] = ...;
  const latlng = new kakao.maps.LatLng(...center);
  latlng.getLat() === center[0]; // false
  ```
  - 위경도 좌표를 카카오 좌표 객체로 변환하고 다시 `[number, number]`로 변환할 때 항등성이 보장되지 않음
  - 탐색할 때 매칭되는 마커를 찾지 못하는 경우가 생겨서 주소 기준으로 탐색하도록 변경
- 이전에 마커 바깥쪽을 클릭하면 사이드바가 닫히도록 구현하였는데, 이에 따른 충돌이 발생하였음
  - 폴리곤은 마커 바깥쪽에 있기 때문에 폴리곤을 클릭하면 "폴리곤 클릭에 의해 사이드바 열림 => 마커 바깥부분 클릭에 의해 사이드바 닫힘"이 순간적으로 발생하여 사이드바가 열리지 않음
  - `kakao.maps.event.addListener`로 등록되는 이벤트 리스너는 자체 제작한 이벤트 객체를 매개변수로 받기 때문에 `evt.stopPropagation()`을 사용할 수 없음
  - 다행히 폴리곤이 svg path 태그로 구현되어 있어서 "마커 바깥부분 클릭시 닫히는" 이벤트 핸들링에서 `evt.target.closest('path')`인 경우만 제외하여 해결
  - 하지만 API 문서에 공식적으로 기술되어있는 사항은 아니라고 생각함
- 마커가 DOM Element라는 가정으로 작성한 코드가 많음. 어쩔 수 없다고 생각함. 

### 스크린 샷
![동글-Chrome-2021-11-12-02-40-08](https://user-images.githubusercontent.com/24454874/141344398-8a520488-51bf-4f63-8f7c-d2b8f052ea2e.gif)

close #78
