### PR TITLE
Feat/signin 회원가입페이지와 API, 미들웨어 구현

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -19,8 +19,6 @@ import { Switch, Route, useLocation } from 'react-router-dom';
 const App: React.FC = () => {
   const location = useLocation();
   const background = location.state && location.state.background;
-  console.log('background', background);
-  console.log('state', location.state);
 
   return (
     <>

--- a/client/src/components/Header/index.tsx
+++ b/client/src/components/Header/index.tsx
@@ -31,8 +31,6 @@ const Header: React.FC = withRouter(({ history, location }) => {
   const [clickedLinkBtnId, setClickedLinkBtnId] = useState('/');
   const [isAuth, setIsAuth] = useRecoilState(authState);
 
-  console.log('isauth', isAuth);
-
   // const openSideBar = useCallback(() => {
   //   console.log('test');
   //   props.showSidebar();

--- a/client/src/components/Searchbar/signIn.tsx
+++ b/client/src/components/Searchbar/signIn.tsx
@@ -1,0 +1,53 @@
+import {
+  SearchbarWrapper,
+  SearchbarInput,
+  SearchbarButton,
+  SearchImg,
+  DropdownWrapper,
+  DropdownItem,
+} from '@components/Searchbar/index.style';
+import { MapInfo, spreadDropdown } from '@controllers/searchbarController';
+
+import React, { useEffect, useState, useRef } from 'react';
+
+const Searchbar: React.FC = () => {
+  const [input, setInput] = useState('');
+  const [results, setResults] = useState<MapInfo[]>([]);
+  const isSpread = useRef(false);
+
+  const inputTagRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    spreadDropdown(input, isSpread.current, setResults);
+  }, [input]);
+
+  return (
+    <>
+      <SearchbarWrapper>
+        <SearchbarInput
+          onChange={(e) => setInput(e.target.value)}
+          ref={inputTagRef}
+        />
+        <SearchbarButton>
+          <SearchImg />
+        </SearchbarButton>
+      </SearchbarWrapper>
+      <DropdownWrapper>
+        {results.length > 0 &&
+          results.map((result, i) => (
+            <DropdownItem
+              key={i}
+              onClick={(e) => {
+                console.log(inputTagRef.current);
+                console.log(e.target);
+              }}
+            >
+              {result.address}
+            </DropdownItem>
+          ))}
+      </DropdownWrapper>
+    </>
+  );
+};
+
+export default Searchbar;

--- a/client/src/components/SignInPlate/index.style.tsx
+++ b/client/src/components/SignInPlate/index.style.tsx
@@ -1,0 +1,33 @@
+import styled, { css } from 'styled-components';
+
+interface SubmitButton {
+  cancel: boolean;
+}
+
+const sizeReact = css`
+  width: 50vw;
+  padding: 5vh;
+`;
+
+export const SignInTitle = styled.div`
+  ${sizeReact}
+  text-align: center;
+  font-size: 20px;
+  font-weight: bold;
+`;
+
+export const ButtonWrapper = styled.div`
+  ${sizeReact}
+  display: flex;
+  flex-direction: row;
+  justify-content: space-around;
+`;
+
+export const SubmitButton = styled.button<SubmitButton>`
+  width: 12vw;
+  height: 5vh;
+  border: none;
+  border-radius: 8px;
+  background-color: ${(props) => (props.cancel ? '#70C49D' : '#33AB74')};
+  color: ${(props) => props.theme.colors.white};
+`;

--- a/client/src/components/SignInPlate/index.tsx
+++ b/client/src/components/SignInPlate/index.tsx
@@ -14,25 +14,33 @@ interface AuthInfo {
   image: string;
 }
 
+interface ErrMsg {
+  err: string;
+}
+
 const SignInPlate: React.FC = () => {
   const [auth, setAuth] = useRecoilState<AuthInfo>(authState);
   const [history, routeHistory] = useHistoryRouter();
 
   const onSubmitClick = async () => {
-    const response = await fetch('/api/v1/address', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json;charset=utf-8',
+    const response = await fetch(
+      `${process.env.REACT_APP_API_URL}/api/v1/address`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json;charset=utf-8',
+        },
+        body: JSON.stringify({
+          oauthEmail: auth.oauth_email,
+          address: '전라북도 전주시 완산구 서신동',
+          image: auth.image,
+        }),
       },
-      body: JSON.stringify({
-        oauthEmail: auth.oauth_email,
-        address: '전주시 완산구 서신동',
-        image: auth.image,
-      }),
-    });
+    );
 
     if (response.status != 200) {
-      alert('올바른 주소로 다시 한 번 제출을 부탁드립니다.');
+      const errMsg: ErrMsg = await response.json();
+      alert(errMsg.err);
     } else {
       setAuth({
         ...auth,
@@ -56,14 +64,14 @@ const SignInPlate: React.FC = () => {
       image: '123',
     });
   };
+  */
 
   useEffect(() => {
-    if (auth.image == '123') {
+    if (auth.address) {
       routeHistory('/', {});
     }
   }, [auth, routeHistory]);
 
-  */
   return (
     <Modal>
       <SignInTitle>

--- a/client/src/components/SignInPlate/index.tsx
+++ b/client/src/components/SignInPlate/index.tsx
@@ -1,11 +1,20 @@
 import React from 'react';
 
+import SearchBar from '@components/Searchbar/signIn';
 import Modal from '@components/modal';
+import { SignInTitle, ButtonWrapper, SubmitButton } from './index.style';
 
 const SignInPlate: React.FC = () => {
   return (
     <Modal>
-      <div>회원가입창</div>
+      <SignInTitle>
+        회원가입을 위해서 우리 동네 정보를 입력해주세요!
+      </SignInTitle>
+      <SearchBar />
+      <ButtonWrapper>
+        <SubmitButton cancel={false}>제출</SubmitButton>
+        <SubmitButton cancel={true}>취소</SubmitButton>
+      </ButtonWrapper>
     </Modal>
   );
 };

--- a/client/src/components/SignInPlate/index.tsx
+++ b/client/src/components/SignInPlate/index.tsx
@@ -1,10 +1,69 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { useRecoilState } from 'recoil';
 
+import { authState } from '@stores/atoms';
 import SearchBar from '@components/Searchbar/signIn';
 import Modal from '@components/modal';
+import useHistoryRouter from '@utils/useRouter';
 import { SignInTitle, ButtonWrapper, SubmitButton } from './index.style';
 
+interface AuthInfo {
+  isLoggedin: boolean;
+  oauth_email: string;
+  address: string;
+  image: string;
+}
+
 const SignInPlate: React.FC = () => {
+  const [auth, setAuth] = useRecoilState<AuthInfo>(authState);
+  const [history, routeHistory] = useHistoryRouter();
+
+  const onSubmitClick = async () => {
+    const response = await fetch('/api/v1/address', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json;charset=utf-8',
+      },
+      body: JSON.stringify({
+        oauthEmail: auth.oauth_email,
+        address: '전주시 완산구 서신동',
+        image: auth.image,
+      }),
+    });
+
+    if (response.status != 200) {
+      alert('올바른 주소로 다시 한 번 제출을 부탁드립니다.');
+    } else {
+      setAuth({
+        ...auth,
+        isLoggedin: true,
+        address: '전주시 완산구 서신동',
+      });
+      routeHistory('/', {});
+    }
+  };
+
+  const onCancelClick = () => {
+    window.location.href = process.env.REACT_APP_MAIN_URL as string;
+  };
+
+  /* history가 이상하게 되어서 확인 필요
+  const onCancelClickTest = () => {
+    //recoil에 있는 값을 다 없애고, mainpage로 routing
+    setAuth({
+      ...auth,
+      oauth_email: '',
+      image: '123',
+    });
+  };
+
+  useEffect(() => {
+    if (auth.image == '123') {
+      routeHistory('/', {});
+    }
+  }, [auth, routeHistory]);
+
+  */
   return (
     <Modal>
       <SignInTitle>
@@ -12,8 +71,12 @@ const SignInPlate: React.FC = () => {
       </SignInTitle>
       <SearchBar />
       <ButtonWrapper>
-        <SubmitButton cancel={false}>제출</SubmitButton>
-        <SubmitButton cancel={true}>취소</SubmitButton>
+        <SubmitButton cancel={false} onClick={onSubmitClick}>
+          제출
+        </SubmitButton>
+        <SubmitButton cancel={true} onClick={onCancelClick}>
+          취소
+        </SubmitButton>
       </ButtonWrapper>
     </Modal>
   );

--- a/client/src/pages/CallbackPage.tsx
+++ b/client/src/pages/CallbackPage.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useCallback } from 'react';
-import { useHistory, useLocation } from 'react-router-dom';
+import React, { useEffect } from 'react';
+import useHistoryRouter from '@utils/useRouter';
 import { useRecoilState } from 'recoil';
 import styled from 'styled-components';
 import qs from 'qs';
@@ -32,19 +32,7 @@ interface AuthInfo {
 
 const CallbackPage: React.FC = () => {
   const [auth, setAuth] = useRecoilState<AuthInfo>(authState);
-  const history = useHistory();
-  const location = useLocation();
-  console.log(location);
-
-  const routeHistory = useCallback(
-    (path: string, state: { [index: string]: string }) => {
-      history.push({
-        pathname: path,
-        state: state,
-      });
-    },
-    [history],
-  );
+  const [history, routeHistory] = useHistoryRouter();
 
   useEffect(() => {
     const getToken = async () => {

--- a/client/src/pages/SignInPage.tsx
+++ b/client/src/pages/SignInPage.tsx
@@ -3,16 +3,16 @@ import styled from 'styled-components';
 
 import SignInPlate from '@components/SignInPlate/index';
 
-const LoginDiv = styled.div`
+const SignInDiv = styled.div`
   width: 100vw;
   height: 100vh;
 `;
 
 const SignInPage: React.FC = () => {
   return (
-    <LoginDiv>
+    <SignInDiv>
       <SignInPlate />
-    </LoginDiv>
+    </SignInDiv>
   );
 };
 

--- a/client/src/utils/useRouter.ts
+++ b/client/src/utils/useRouter.ts
@@ -1,0 +1,21 @@
+import { useCallback } from 'react';
+import { useHistory, useLocation } from 'react-router-dom';
+
+export default () => {
+  const history = useHistory();
+  const location = useLocation();
+
+  const routeHistory = useCallback(
+    (path: string, state: { [index: string]: string }) => {
+      console.log('전', location);
+      history.push({
+        pathname: path,
+        state: state,
+      });
+      console.log('후', location);
+    },
+    [history],
+  );
+
+  return [history, routeHistory];
+};

--- a/client/src/utils/useRouter.ts
+++ b/client/src/utils/useRouter.ts
@@ -7,12 +7,10 @@ export default () => {
 
   const routeHistory = useCallback(
     (path: string, state: { [index: string]: string }) => {
-      console.log('전', location);
       history.push({
         pathname: path,
         state: state,
       });
-      console.log('후', location);
     },
     [history],
   );

--- a/server/src/api/authController.ts
+++ b/server/src/api/authController.ts
@@ -76,7 +76,6 @@ router.post('/auth', (async (req: Request, res: Response) => {
 router.post('/address', (async (req: Request, res: Response) => {
   const { oauthEmail, address, image }: UserInfo = req.body as UserInfo;
   const userRegionInfo = await findRegionInfo(address);
-  console.log('찾기끝남', userRegionInfo);
 
   if (userRegionInfo) {
     const newUserInfo: User = {

--- a/server/src/api/authController.ts
+++ b/server/src/api/authController.ts
@@ -51,6 +51,7 @@ router.post('/auth', (async (req: Request, res: Response) => {
   const isMember = await isMemberService(oauthEmail.oauth_email);
   if (isMember) {
     const jwtToken = jwt.sign(oauthEmail);
+
     const userInfo = {
       jwtToken: jwtToken.token,
       oauthEmail: isMember.oauth_email,

--- a/server/src/api/authController.ts
+++ b/server/src/api/authController.ts
@@ -1,12 +1,23 @@
 import express, { Request, Response, RequestHandler } from 'express';
+import { User } from '@models/User';
 import axios, { AxiosResponse } from 'axios';
-import isMemberService from '@services/authService';
+import {
+  isMemberService,
+  findRegionInfo,
+  saveUserInfo,
+} from '@services/authService';
 import jwt from '@services/jwtService';
 
 const router: express.Router = express.Router();
 
 interface Code {
   code: string;
+}
+
+interface UserInfo {
+  oauthEmail: string;
+  address: string;
+  image: string;
 }
 
 router.post('/auth', (async (req: Request, res: Response) => {
@@ -59,6 +70,30 @@ router.post('/auth', (async (req: Request, res: Response) => {
   }
 
   // refactoring 필요: login, avatar_url만 반환해야 하는데 typescript 어렵다..
+}) as RequestHandler);
+
+router.post('/address', (async (req: Request, res: Response) => {
+  const { oauthEmail, address, image }: UserInfo = req.body as UserInfo;
+  const userRegionInfo = await findRegionInfo(address);
+  console.log('찾기끝남', userRegionInfo);
+
+  if (userRegionInfo) {
+    const newUserInfo: User = {
+      oauth_email: oauthEmail,
+      address,
+      code: userRegionInfo.code,
+      center: userRegionInfo.center,
+      image,
+    };
+    const isSave = await saveUserInfo(newUserInfo);
+    if (isSave) {
+      res.status(200).send({ msg: 'success' });
+    } else {
+      res.status(404).send({ err: '이미 회원가입하셨습니다' });
+    }
+  } else {
+    res.status(404).send({ err: 'db에 없는 주소입니다' });
+  }
 }) as RequestHandler);
 
 export default router;

--- a/server/src/middlewares/auth.ts
+++ b/server/src/middlewares/auth.ts
@@ -1,0 +1,45 @@
+import express, {
+  Request,
+  Response,
+  NextFunction,
+  RequestHandler,
+} from 'express';
+import jwt from '@services/jwtService';
+import { JwtPayload } from 'jsonwebtoken';
+
+const TOKEN_EXPIRED = -3;
+const TOKEN_INVALID = -2;
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace Express {
+    interface Request {
+      id: string;
+    }
+  }
+}
+
+const checkToken: RequestHandler = (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  const token: string = req.headers.token as string;
+  // 토큰 없음
+  if (!token) return res.json({ code: 404 });
+  // decode
+  const user = jwt.verify(token);
+  // 유효기간 만료
+  if (user === TOKEN_EXPIRED) return res.json({ code: 404 });
+  // 유효하지 않는 토큰
+  if (user === TOKEN_INVALID) return res.json({ code: 404 });
+
+  if ((user as JwtPayload).oauth_email === undefined)
+    return res.json({ code: 404 });
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  req.id = (user as JwtPayload).oauth_email;
+  next();
+};
+
+module.exports = checkToken;

--- a/server/src/services/authService.ts
+++ b/server/src/services/authService.ts
@@ -7,7 +7,6 @@ const isMember = async (oauth_email: string): Promise<User | null> => {
 };
 
 const findRegionInfo = async (address: string): Promise<MapInfo | null> => {
-  console.log('찾기', address);
   return await MapInfoModel.findOne().where('address').equals(address);
 };
 

--- a/server/src/services/authService.ts
+++ b/server/src/services/authService.ts
@@ -1,8 +1,25 @@
 import { User, UserModel } from '@models/User';
+import { MapInfo, MapInfoModel } from '@models/MapInfo';
 import { ObjectId } from 'mongoose';
 
 const isMember = async (oauth_email: string): Promise<User | null> => {
   return await UserModel.findOne().where('oauth_email').equals(oauth_email);
 };
 
-export default isMember;
+const findRegionInfo = async (address: string): Promise<MapInfo | null> => {
+  console.log('찾기', address);
+  return await MapInfoModel.findOne().where('address').equals(address);
+};
+
+const saveUserInfo = async (userInfo: User): Promise<string> => {
+  const newUser = new UserModel(userInfo);
+
+  try {
+    await newUser.save();
+    return 'success';
+  } catch (err) {
+    return '';
+  }
+};
+
+export { isMember as isMemberService, findRegionInfo, saveUserInfo };

--- a/server/src/services/jwtService.ts
+++ b/server/src/services/jwtService.ts
@@ -32,14 +32,10 @@ export default {
     } catch (err) {
       const errMsg = (err as Error).message;
       if (errMsg === 'jwt expired') {
-        console.log('expired token');
         return TOKEN_EXPIRED;
       } else if (errMsg === 'invalid token') {
-        console.log('invalid token');
-        console.log(TOKEN_INVALID);
         return TOKEN_INVALID;
       } else {
-        console.log('invalid token');
         return TOKEN_INVALID;
       }
     }


### PR DESCRIPTION
### 🔨 작업 내용 설명
회원가입페이지와 API, 미들웨어 구현

### 📑 구현한 내용
- [ ] 회원가입 페이지 장소 검색 임시로 만들어 놓음
- [x] 회원가입 제출하면 db에 저장, recoil에 저장, 메인페이지로 routing
- [x] 회원가입 취소하면 메인페이지로 routing
- [x] 로그인여부 미들웨어 만들기

### 🚧 주의 사항
- backend에서 도저히 해결되지 않는 오류는 disable 주석을 이용해서 해결했습니다. 리팩토링이 필요합니다.
- 프로필에서 사용되는 주소 검색이 회원가입에도 똑같이 사용되어 임시로만 만들어 놓았습니다. (승용님과 논의 필요)
- 장소를 검색할 때, 만약 db에서 center, code 모두 가져오는 것이라면 현재 로직을 수정해야 합니다. 우선은 이름만 가져온다는 가정하에서 backend에서 mapInfo db를 탐색한 뒤 user에 정보르 저장하는 것으로 했습니다.
- 비회원이 로그인 누르고 나서 front에는 해당 회원의 아이디와 imageURL이 옵니다. 이후 주소를 입력하고 제출을 누르면 db에 저장하는 업무가 수행되어야 하기 때문에 이전에 받았던 회원의 아이디와 imageURL을 front에서 back으로 주어야 합니다. 그래서 이 두 값을 잠시 front에서 보관을 해야 하고, recoil 또는 storage or cookie 였습니다. 우선은 recoil을 선택했는데 재렌더링의 성능 저하가 염려됩니다. 그래도 보안은 더 낫지 않나 싶어서 선택했습니다.
- routeHistory이 자주 사용되어서 따로 custom Hook으로 만들어서 utils에 넣었습니다.
- routeHistory가 생명주기와 엮여서 useEffect에서만 작동하는 것을 확인했습니다. 아직 이해가 안 되어서 고쳐야 할 부분입니다.

[### 스크린 샷]
[시연영상_유튜브](https://youtu.be/Z028Z7YAaO4)
routing 문제는 영상 마지막에 구현해 놓았습니다.
[issue | close] #[ISSUE_NUMBER]
