### PR TITLE
Feat/profile page 구현 완료

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -36,20 +36,24 @@ const App: React.FC = () => {
       <GlobalStyle />
       <ThemeProvider theme={myTheme}>
         <GlobalStore>
-          <Header />
+          <ContentWrapper>
+            <Header />
 
-          <Switch location={background || location}>
-            <Route exact path="/" component={MainPage} />
-            <Route path="/review" component={ReviewPage} />
-            <Route path="/signin" component={SignInPage} />
-            <Route path="/github/callback" component={LoadingPage} />
-            <Route path="/signup" component={SignUpPage} />
-            <Route path="/profile" component={ProfilePage} />
-            <Route component={NotFoundPage} />
-          </Switch>
-          {background && <Route path="/write-review" component={ReviewModal} />}
-          {background && <Route path="/ranking" render={RankingPage} />}
-          {background && <Route path="/signin" render={SignInPage} />}
+            <Switch location={background || location}>
+              <Route exact path="/" component={MainPage} />
+              <Route path="/review" component={ReviewPage} />
+              <Route path="/signin" component={SignInPage} />
+              <Route path="/github/callback" component={LoadingPage} />
+              <Route path="/signup" component={SignUpPage} />
+              <Route path="/profile" component={ProfilePage} />
+              <Route component={NotFoundPage} />
+            </Switch>
+            {background && (
+              <Route path="/write-review" component={ReviewModal} />
+            )}
+            {background && <Route path="/ranking" render={RankingPage} />}
+            {background && <Route path="/signin" render={SignInPage} />}
+          </ContentWrapper>
         </GlobalStore>
       </ThemeProvider>
     </>

--- a/client/src/assets/icons/x.svg
+++ b/client/src/assets/icons/x.svg
@@ -1,0 +1,1 @@
+<svg width="24px" height="24px" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-x"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>

--- a/client/src/components/AddressModal/index.style.tsx
+++ b/client/src/components/AddressModal/index.style.tsx
@@ -28,8 +28,8 @@ const ButtonWrapper = styled.div`
 `;
 
 const SubmitButton = styled.button<SubmitButton>`
-  width: 60px;
-  height: 40px;
+  width: 80px;
+  height: 60px;
   border: none;
   border-radius: 8px;
   background: ${(props) =>

--- a/client/src/components/AddressModal/index.tsx
+++ b/client/src/components/AddressModal/index.tsx
@@ -14,14 +14,12 @@ interface AddressModalProps {
   title: string;
   onSubmitHandler;
   onCancelHandler;
-  toggleModal?: () => void;
 }
 
 const AddressModal: React.FC<AddressModalProps> = ({
   title,
   onSubmitHandler,
   onCancelHandler,
-  toggleModal,
 }) => {
   const [mapInfo, setMapInfo] = useState<IMapInfo>({} as IMapInfo);
 
@@ -30,7 +28,7 @@ const AddressModal: React.FC<AddressModalProps> = ({
   };
 
   return (
-    <Modal toggleModal={toggleModal}>
+    <Modal>
       <ModalSizer>
         <TitleWrapper>{title}</TitleWrapper>
         <Searchbar

--- a/client/src/components/AddressModal/index.tsx
+++ b/client/src/components/AddressModal/index.tsx
@@ -23,7 +23,7 @@ const AddressModal: React.FC<AddressModalProps> = ({
   onCancelHandler,
   toggleModal,
 }) => {
-  const [mapInfo, setMapInfo] = useState({});
+  const [mapInfo, setMapInfo] = useState<IMapInfo>({} as IMapInfo);
 
   const onClickHandler = (mapInfo: IMapInfo) => {
     setMapInfo(mapInfo);
@@ -33,7 +33,10 @@ const AddressModal: React.FC<AddressModalProps> = ({
     <Modal toggleModal={toggleModal}>
       <ModalSizer>
         <TitleWrapper>{title}</TitleWrapper>
-        <Searchbar onClickHandler={onClickHandler} />
+        <Searchbar
+          onClickHandler={onClickHandler}
+          valueState={mapInfo.address}
+        />
       </ModalSizer>
       <ButtonWrapper>
         <SubmitButton cancel={false} onClick={() => onSubmitHandler(mapInfo)}>

--- a/client/src/components/AddressModal/index.tsx
+++ b/client/src/components/AddressModal/index.tsx
@@ -39,7 +39,13 @@ const AddressModal: React.FC<AddressModalProps> = ({
         />
       </ModalSizer>
       <ButtonWrapper>
-        <SubmitButton cancel={false} onClick={() => onSubmitHandler(mapInfo)}>
+        <SubmitButton
+          cancel={false}
+          onClick={async () => {
+            await onSubmitHandler(mapInfo);
+            onCancelHandler();
+          }}
+        >
           제출
         </SubmitButton>
         <SubmitButton cancel={true} onClick={onCancelHandler}>

--- a/client/src/components/AddressModal/index.tsx
+++ b/client/src/components/AddressModal/index.tsx
@@ -36,6 +36,7 @@ const AddressModal: React.FC<AddressModalProps> = ({
         <Searchbar
           onClickHandler={onClickHandler}
           valueState={mapInfo.address}
+          onlyDong={true}
         />
       </ModalSizer>
       <ButtonWrapper>

--- a/client/src/components/Common/Modal/index.style.tsx
+++ b/client/src/components/Common/Modal/index.style.tsx
@@ -1,3 +1,5 @@
+import xIcon from '@assets/icons/x.svg';
+
 import styled from 'styled-components';
 
 const ModalOverlay = styled.div`
@@ -39,6 +41,12 @@ const ModalCloseBtnDiv = styled.div`
   width: 100%;
 `;
 
+const ModalCloseImage = styled.img`
+  width: 100%;
+  height: 100%;
+`;
+ModalCloseImage.defaultProps = { src: xIcon };
+
 const ModalCloseBtn = styled.button`
   border: none;
   background-color: transparent;
@@ -60,6 +68,7 @@ export {
   ModalOverlay,
   ModalWrapper,
   ModalCloseBtnDiv,
+  ModalCloseImage,
   ModalCloseBtn,
   ChildrenWrapper,
 };

--- a/client/src/components/Common/Modal/index.tsx
+++ b/client/src/components/Common/Modal/index.tsx
@@ -23,6 +23,7 @@ const Modal: React.FC<ModalProps> = ({ children, toggleModal }) => {
 
   const onClick = () => {
     setIsActive(!isActive);
+    history.goBack();
   };
 
   // scroll 작동 금지
@@ -77,7 +78,7 @@ const Modal: React.FC<ModalProps> = ({ children, toggleModal }) => {
     <>
       {isActive && (
         <ModalOverlay>
-          <ModalWrapper className="modal" ref={modalRef}>
+          <ModalWrapper ref={modalRef}>
             <ModalCloseBtnDiv>
               <ModalCloseBtn onClick={onClick}>
                 <ModalCloseImage />

--- a/client/src/components/Common/Modal/index.tsx
+++ b/client/src/components/Common/Modal/index.tsx
@@ -2,6 +2,7 @@ import {
   ModalOverlay,
   ModalWrapper,
   ModalCloseBtnDiv,
+  ModalCloseImage,
   ModalCloseBtn,
   ChildrenWrapper,
 } from '@components/Common/Modal/index.style';
@@ -78,7 +79,9 @@ const Modal: React.FC<ModalProps> = ({ children, toggleModal }) => {
         <ModalOverlay>
           <ModalWrapper className="modal" ref={modalRef}>
             <ModalCloseBtnDiv>
-              <ModalCloseBtn onClick={onClick}>✖</ModalCloseBtn>
+              <ModalCloseBtn onClick={onClick}>
+                <ModalCloseImage />
+              </ModalCloseBtn>
             </ModalCloseBtnDiv>
             <ChildrenWrapper>{children}</ChildrenWrapper>
           </ModalWrapper>

--- a/client/src/components/Common/Modal/index.tsx
+++ b/client/src/components/Common/Modal/index.tsx
@@ -10,13 +10,9 @@ import {
 import React, { useState, useEffect, useRef } from 'react';
 import { useHistory } from 'react-router-dom';
 
-interface ModalProps {
-  toggleModal?: () => void;
-}
-
 // "상위 컴포넌트에서는 클릭하면 무조건 추가한다"로 로직을 구성
 // recoil에서 전역ㅇ로 관리하는 것도 생각해 볼 수 있으려나..
-const Modal: React.FC<ModalProps> = ({ children, toggleModal }) => {
+const Modal: React.FC = ({ children }) => {
   const history = useHistory();
   const [isActive, setIsActive] = useState(true);
   const modalRef = useRef<HTMLDivElement>(null);

--- a/client/src/components/Profile/index.tsx
+++ b/client/src/components/Profile/index.tsx
@@ -75,12 +75,8 @@ const Profile: React.FC = withRouter(({ history, location }) => {
       {isModal && (
         <AddressModal
           title="우리 동네를 입력해주세요!"
-          onSubmitHandler={() => {
-            console.log('?');
-          }}
-          onCancelHandler={() => {
-            console.log('?');
-          }}
+          onSubmitHandler={updateAddress(auth, setAuth)}
+          onCancelHandler={toggleModal}
           toggleModal={toggleModal}
         />
       )}

--- a/client/src/components/Profile/index.tsx
+++ b/client/src/components/Profile/index.tsx
@@ -9,36 +9,24 @@ import {
   AddressWrapper,
 } from '@components/Profile/index.style';
 import { authState } from '@stores/atoms';
-import AddressModal from '@components/AddressModal/index';
 import {
   uploadImage,
   deleteImage,
   updateAddress,
 } from '@controllers/profileController';
+import useHistoryRouter from '@hooks/useHistoryRouter';
 
-import React, { useState, useRef } from 'react';
-import { useHistory, useLocation } from 'react-router-dom';
+import React, { useRef } from 'react';
 import { useRecoilState } from 'recoil';
+import { useLocation } from 'react-router-dom';
 
 const Profile: React.FC = () => {
-  const history = useHistory();
+  const [history, routeHistory] = useHistoryRouter();
   const location = useLocation();
 
   const [auth, setAuth] = useRecoilState(authState);
-  const [isModal, setIsModal] = useState(
-    location.pathname === '/profile/update-address',
-  );
 
   const hiddenInputRef = useRef<HTMLInputElement | null>(null);
-
-  const toggleModal = () => {
-    if (!isModal) {
-      history.push(`profile/update-address`);
-    } else {
-      history.goBack();
-    }
-    setIsModal((prev) => !prev);
-  };
 
   const inputClickPasser = () => {
     if (hiddenInputRef.current !== null) {
@@ -77,15 +65,13 @@ const Profile: React.FC = () => {
         <OauthnameWrapper>{auth.oauth_email.split('_')[0]}</OauthnameWrapper>
         <UsernameWrapper>{auth.oauth_email.split('_')[1]}</UsernameWrapper>
       </ImageUsernameWrapper>
-      <AddressWrapper onClick={toggleModal}>{auth.address}</AddressWrapper>
-      {isModal && (
-        <AddressModal
-          title="우리 동네를 입력해주세요!"
-          onSubmitHandler={updateAddress(auth, setAuth)}
-          onCancelHandler={toggleModal}
-          toggleModal={toggleModal}
-        />
-      )}
+      <AddressWrapper
+        onClick={() =>
+          routeHistory('profile/update-address', { background: location })
+        }
+      >
+        {auth.address}
+      </AddressWrapper>
     </>
   );
 };

--- a/client/src/components/Profile/index.tsx
+++ b/client/src/components/Profile/index.tsx
@@ -34,6 +34,8 @@ const Profile: React.FC = () => {
   const toggleModal = () => {
     if (!isModal) {
       history.push(`profile/update-address`);
+    } else {
+      history.goBack();
     }
     setIsModal((prev) => !prev);
   };

--- a/client/src/components/Profile/index.tsx
+++ b/client/src/components/Profile/index.tsx
@@ -17,19 +17,23 @@ import {
 } from '@controllers/profileController';
 
 import React, { useState, useRef } from 'react';
-import { withRouter } from 'react-router-dom';
+import { useHistory, useLocation } from 'react-router-dom';
 import { useRecoilState } from 'recoil';
 
-const Profile: React.FC = withRouter(({ history, location }) => {
+const Profile: React.FC = () => {
+  const history = useHistory();
+  const location = useLocation();
+
   const [auth, setAuth] = useRecoilState(authState);
+  const [isModal, setIsModal] = useState(
+    location.pathname === '/profile/update-address',
+  );
 
   const hiddenInputRef = useRef<HTMLInputElement | null>(null);
 
-  const [isModal, setIsModal] = useState(false);
-
   const toggleModal = () => {
     if (!isModal) {
-      history.push(`${location.pathname}/update-address`);
+      history.push(`profile/update-address`);
     }
     setIsModal((prev) => !prev);
   };
@@ -82,6 +86,6 @@ const Profile: React.FC = withRouter(({ history, location }) => {
       )}
     </>
   );
-});
+};
 
 export default Profile;

--- a/client/src/components/Searchbar/index.tsx
+++ b/client/src/components/Searchbar/index.tsx
@@ -14,11 +14,13 @@ import { IMapInfo } from '@myTypes/Map';
 interface SearchbarProps {
   onClickHandler: (mapInfo: IMapInfo) => void | Promise<void>;
   valueState?: string;
+  onlyDong?: boolean;
 }
 
 const Searchbar: React.FC<SearchbarProps> = ({
   onClickHandler,
   valueState,
+  onlyDong = false,
 }) => {
   const [input, setInput] = useState('');
 
@@ -27,7 +29,7 @@ const Searchbar: React.FC<SearchbarProps> = ({
   const inputTagRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
-    spreadDropdown(input, isSpread.current, setResults);
+    spreadDropdown(input, isSpread.current, setResults, onlyDong);
   }, [input]);
 
   useEffect(() => {

--- a/client/src/components/Searchbar/index.tsx
+++ b/client/src/components/Searchbar/index.tsx
@@ -13,9 +13,13 @@ import { IMapInfo } from '@myTypes/Map';
 
 interface SearchbarProps {
   onClickHandler: (mapInfo: IMapInfo) => void | Promise<void>;
+  valueState?: string;
 }
 
-const Searchbar: React.FC<SearchbarProps> = ({ onClickHandler }) => {
+const Searchbar: React.FC<SearchbarProps> = ({
+  onClickHandler,
+  valueState,
+}) => {
   const [input, setInput] = useState('');
 
   const [results, setResults] = useState<IMapInfo[]>([]);
@@ -25,6 +29,12 @@ const Searchbar: React.FC<SearchbarProps> = ({ onClickHandler }) => {
   useEffect(() => {
     spreadDropdown(input, isSpread.current, setResults);
   }, [input]);
+
+  useEffect(() => {
+    if (inputTagRef.current !== null && valueState) {
+      inputTagRef.current.value = valueState;
+    }
+  }, [valueState]);
 
   return (
     <div>
@@ -45,7 +55,7 @@ const Searchbar: React.FC<SearchbarProps> = ({ onClickHandler }) => {
               onClick={(e) => {
                 onClickHandler(result);
                 setResults([]);
-                if (inputTagRef.current !== null) {
+                if (inputTagRef.current !== null && !valueState) {
                   inputTagRef.current.value = '';
                 }
               }}

--- a/client/src/controllers/profileController.ts
+++ b/client/src/controllers/profileController.ts
@@ -13,34 +13,34 @@ const uploadImage = async (e, auth, setAuth) => {
       body: formData,
     },
   );
+  const result = await response.json();
   if (response.status === 200) {
-    const result = (await response.json()).result;
     setAuth((prev) => ({
       ...prev,
-      image: result.image,
+      image: result.result,
     }));
   } else {
-    console.error('uploadImage 요청이 잘못되었어요.');
+    console.error(result.message);
   }
 };
 
 const deleteImage = async (auth, setAuth) => {
   const response = await fetch(
-    `${process.env.REACT_APP_API_URL}/api/user/profile-image?username=${
+    `${process.env.REACT_APP_API_URL}/api/user/profile-image?oauth_email=${
       auth.oauth_email
-    }&imageURL=${encodeURIComponent(auth.image)}`,
+    }&image=${encodeURIComponent(auth.image)}`,
     {
       method: 'DELETE',
     },
   );
+  const result = await response.json();
   if (response.status === 200) {
-    const result = await response.json();
     setAuth((prev) => ({
       ...prev,
-      image: result.result.image,
+      image: result.result,
     }));
   } else {
-    console.error('deleteImage 요청이 잘못되었어요.');
+    console.error(result.message);
   }
 };
 
@@ -51,13 +51,17 @@ const updateAddress = (auth, setAuth) => async (mapInfo: IMapInfo) => {
       method: 'PATCH',
       headers: { 'Content-type': 'application/json' },
       body: JSON.stringify({
-        prevAddress: auth.address,
-        newAddress: mapInfo.address,
+        oauth_email: auth.oauth_email,
+        address: mapInfo.address,
       }),
     },
   );
   const result = await response.json();
-  setAuth((prev) => ({ ...prev, address: result.address }));
+  if (response.status === 200) {
+    setAuth((prev) => ({ ...prev, address: result.result }));
+  } else {
+    console.error(result.message);
+  }
 };
 
 export { uploadImage, deleteImage, updateAddress };

--- a/client/src/controllers/profileController.ts
+++ b/client/src/controllers/profileController.ts
@@ -13,11 +13,15 @@ const uploadImage = async (e, auth, setAuth) => {
       body: formData,
     },
   );
-  const result = await response.json();
-  setAuth((prev) => ({
-    ...prev,
-    image: result.image,
-  }));
+  if (response.status === 200) {
+    const result = (await response.json()).result;
+    setAuth((prev) => ({
+      ...prev,
+      image: result.image,
+    }));
+  } else {
+    console.error('uploadImage 요청이 잘못되었어요.');
+  }
 };
 
 const deleteImage = async (auth, setAuth) => {
@@ -29,8 +33,15 @@ const deleteImage = async (auth, setAuth) => {
       method: 'DELETE',
     },
   );
-  const result = await response.json();
-  setAuth((prev) => ({ ...prev, image: result.image }));
+  if (response.status === 200) {
+    const result = await response.json();
+    setAuth((prev) => ({
+      ...prev,
+      image: result.result.image,
+    }));
+  } else {
+    console.error('deleteImage 요청이 잘못되었어요.');
+  }
 };
 
 const updateAddress = (auth, setAuth) => async (mapInfo: IMapInfo) => {

--- a/client/src/controllers/searchbarController.ts
+++ b/client/src/controllers/searchbarController.ts
@@ -1,10 +1,16 @@
 import { IAPIResult } from '@myTypes/Common';
 import { IMapInfo } from '@myTypes/Map';
 
-const spreadDropdown = async (keyword, isSpread, setResults) => {
+const spreadDropdown = async (
+  keyword,
+  isSpread,
+  setResults,
+  onlyDong = false,
+) => {
   const searchRegions = async (): Promise<IAPIResult<IMapInfo[] | []>> => {
+    const onlyDongQuery = onlyDong ? '&onlyDong=true' : '';
     return await fetch(
-      `${process.env.REACT_APP_API_URL}/api/map/search?keyword=${keyword}`,
+      `${process.env.REACT_APP_API_URL}/api/map/search?keyword=${keyword}${onlyDongQuery}`,
     )
       .then(async (response) => {
         if (response.status === 200) {

--- a/client/src/hooks/useHistoryRouter.ts
+++ b/client/src/hooks/useHistoryRouter.ts
@@ -1,9 +1,8 @@
 import { useCallback } from 'react';
-import { useHistory, useLocation } from 'react-router-dom';
+import { useHistory } from 'react-router-dom';
 
 export default () => {
   const history = useHistory();
-  const location = useLocation();
 
   const routeHistory = useCallback(
     (path: string, state: { [index: string]: string }) => {

--- a/client/src/pages/ProfileAddressPage.tsx
+++ b/client/src/pages/ProfileAddressPage.tsx
@@ -1,0 +1,31 @@
+import AddressModal from '@components/AddressModal/index';
+import { updateAddress } from '@controllers/profileController';
+import { authState } from '@stores/atoms';
+import { useRecoilState } from 'recoil';
+import useHistoryRouter from '@hooks/useHistoryRouter';
+
+import React from 'react';
+import styled from 'styled-components';
+
+const AddressWrapper = styled.div`
+  width: 100%;
+  height: 100%;
+`;
+
+const ProfileAddressPage: React.FC = () => {
+  const [history, routeHistory] = useHistoryRouter();
+
+  const [auth, setAuth] = useRecoilState(authState);
+
+  return (
+    <AddressWrapper>
+      <AddressModal
+        title="우리 동네를 입력해주세요!"
+        onSubmitHandler={updateAddress(auth, setAuth)}
+        onCancelHandler={() => history.goBack()}
+      />
+    </AddressWrapper>
+  );
+};
+
+export default ProfileAddressPage;

--- a/client/src/pages/index.ts
+++ b/client/src/pages/index.ts
@@ -6,6 +6,7 @@ import SignInPage from '@pages/SignInPage';
 import LoadingPage from '@pages/LoadingPage';
 import SignUpPage from '@pages/SignUpPage';
 import ProfilePage from '@pages/ProfilePage';
+import ProfileAddressPage from '@pages/ProfileAddressPage';
 
 export {
   NotFoundPage,
@@ -16,4 +17,5 @@ export {
   LoadingPage,
   SignUpPage,
   ProfilePage,
+  ProfileAddressPage,
 };

--- a/server/src/api/mapController.ts
+++ b/server/src/api/mapController.ts
@@ -51,10 +51,10 @@ router.get('/rates', (async (req: Request, res: Response) => {
 }) as RequestHandler);
 
 router.get('/search', (async (req: Request, res: Response) => {
-  const { keyword } = req.query;
+  const { keyword, onlyDong } = req.query;
   try {
     if (typeof keyword === 'string' && keyword.length > 0) {
-      const center = await mapService.queryCenter(keyword);
+      const center = await mapService.queryCenter(keyword, !!onlyDong);
       res.status(200).json(makeApiResponse(center, ''));
     } else {
       res.status(200).json(makeApiResponse([], ''));

--- a/server/src/api/userController.ts
+++ b/server/src/api/userController.ts
@@ -1,4 +1,6 @@
 import { userService } from '@services/index';
+import { makeApiResponse } from '@utils/index';
+import logger from '@loaders/loggerLoader';
 
 import express, { Request, RequestHandler, Response } from 'express';
 import multer, { FileFilterCallback } from 'multer';
@@ -10,8 +12,8 @@ interface ProfileImageBody {
 }
 
 interface ProfileAddressBody {
-  prevAddress: string;
-  newAddress: string;
+  oauth_email: string;
+  address: string;
 }
 
 const validateFileType = (
@@ -47,18 +49,31 @@ router.patch(
     const body: ProfileImageBody = req.body as ProfileImageBody;
     const { oauth_email, image: prevImage } = body;
 
-    let image = `${process.env.IMAGE_ENDPOINT as string}/${
-      process.env.IMAGE_BUCKET as string
-    }/user-profile.png`;
-    if (req.file) {
-      image = await userService.patchProfileImage(
-        oauth_email,
-        prevImage,
-        req.file,
-      );
+    if (oauth_email && prevImage && req.file) {
+      try {
+        let image = `${process.env.IMAGE_ENDPOINT as string}/${
+          process.env.IMAGE_BUCKET as string
+        }/user-profile.png`;
+        image = await userService.patchProfileImage(
+          oauth_email,
+          prevImage,
+          req.file,
+        );
+        res
+          .status(200)
+          .json(makeApiResponse(image, '이미지를 성공적으로 업데이트했어요.'));
+      } catch (error) {
+        const err = error as Error;
+        logger.error(err.message);
+        res
+          .status(500)
+          .json(
+            makeApiResponse({}, '이미지를 정상적으로 업데이트하지 못했어요.'),
+          );
+      }
+    } else {
+      res.status(500).json(makeApiResponse({}, '필요한 바디가 비었어요.'));
     }
-
-    res.json({ image });
   },
 );
 
@@ -67,10 +82,23 @@ router.delete('/profile-image', (async (req: Request, res: Response) => {
   const { oauth_email, image } = query;
 
   if (oauth_email && image) {
-    await userService.deleteProfileImage(
-      oauth_email as string,
-      image as string,
-    );
+    try {
+      const result = await userService.deleteProfileImage(
+        oauth_email as string,
+        image as string,
+      );
+      res
+        .status(200)
+        .json(makeApiResponse(result, '성공적으로 이미지를 삭제했어요.'));
+    } catch (error) {
+      const err = error as Error;
+      logger.error(err.message);
+      res
+        .status(500)
+        .json(makeApiResponse({}, '이미지를 정상적으로 삭제하지 못했어요.'));
+    }
+  } else {
+    res.status(500).json(makeApiResponse({}, '필요한 쿼리스트링이 비었어요.'));
   }
 
   res.json({
@@ -82,12 +110,29 @@ router.delete('/profile-image', (async (req: Request, res: Response) => {
 
 router.patch('/profile-address', (async (req: Request, res: Response) => {
   const body: ProfileAddressBody = req.body as ProfileAddressBody;
-  const { prevAddress, newAddress } = body;
-  const updateResult = await userService.updateAddress(prevAddress, newAddress);
-  if (updateResult) {
-    res.json({ address: newAddress });
+  const { oauth_email, address } = body;
+  if (oauth_email && address) {
+    try {
+      const updateResult = await userService.updateAddress(
+        oauth_email,
+        address,
+      );
+      if (updateResult) {
+        res
+          .status(200)
+          .json(makeApiResponse({ address }, '주소 업데이트에 성공했어요.'));
+      } else {
+        res.status(200).json(makeApiResponse({}, '일치하는 아이디가 없어요.'));
+      }
+    } catch (error) {
+      const err = error as Error;
+      logger.error(err.message);
+      res
+        .status(500)
+        .json(makeApiResponse({}, '주소를 정상적으로 업데이트하지 못했어요.'));
+    }
   } else {
-    res.json({ address: prevAddress });
+    res.status(500).json(makeApiResponse({}, '필요한 바디가 비었어요.'));
   }
 }) as RequestHandler);
 

--- a/server/src/api/userController.ts
+++ b/server/src/api/userController.ts
@@ -49,7 +49,9 @@ router.patch(
     const body: ProfileImageBody = req.body as ProfileImageBody;
     const { oauth_email, image: prevImage } = body;
 
-    if (oauth_email && prevImage && req.file) {
+    console.log(oauth_email, prevImage);
+
+    if (oauth_email && req.file) {
       try {
         let image = `${process.env.IMAGE_ENDPOINT as string}/${
           process.env.IMAGE_BUCKET as string
@@ -83,13 +85,13 @@ router.delete('/profile-image', (async (req: Request, res: Response) => {
 
   if (oauth_email && image) {
     try {
-      const result = await userService.deleteProfileImage(
+      await userService.deleteProfileImage(
         oauth_email as string,
         image as string,
       );
       res
         .status(200)
-        .json(makeApiResponse(result, '성공적으로 이미지를 삭제했어요.'));
+        .json(makeApiResponse('', '성공적으로 이미지를 삭제했어요.'));
     } catch (error) {
       const err = error as Error;
       logger.error(err.message);
@@ -100,12 +102,6 @@ router.delete('/profile-image', (async (req: Request, res: Response) => {
   } else {
     res.status(500).json(makeApiResponse({}, '필요한 쿼리스트링이 비었어요.'));
   }
-
-  res.json({
-    image: `${process.env.IMAGE_ENDPOINT as string}/${
-      process.env.IMAGE_BUCKET as string
-    }/user-profile.png`,
-  });
 }) as RequestHandler);
 
 router.patch('/profile-address', (async (req: Request, res: Response) => {
@@ -120,9 +116,9 @@ router.patch('/profile-address', (async (req: Request, res: Response) => {
       if (updateResult) {
         res
           .status(200)
-          .json(makeApiResponse({ address }, '주소 업데이트에 성공했어요.'));
+          .json(makeApiResponse(address, '주소 업데이트에 성공했어요.'));
       } else {
-        res.status(200).json(makeApiResponse({}, '일치하는 아이디가 없어요.'));
+        res.status(500).json(makeApiResponse({}, '일치하는 아이디가 없어요.'));
       }
     } catch (error) {
       const err = error as Error;

--- a/server/src/services/mapService.ts
+++ b/server/src/services/mapService.ts
@@ -37,8 +37,14 @@ const queryPolygon = async (
   return result;
 };
 
-const queryCenter = async (keyword: string): Promise<MapInfo[]> => {
-  return await MapInfoModel.find({ address: { $regex: RegExp(keyword, 'g') } });
+const queryCenter = async (
+  keyword: string,
+  onlyDong: boolean,
+): Promise<MapInfo[]> => {
+  const query = onlyDong
+    ? { address: { $regex: RegExp(keyword, 'g') }, codeLength: 7 }
+    : { address: { $regex: RegExp(keyword, 'g') } };
+  return await MapInfoModel.find(query);
 };
 
 const queryRates = async (

--- a/server/src/services/userService.ts
+++ b/server/src/services/userService.ts
@@ -68,7 +68,10 @@ const deleteProfileImage = async (oauth_email: string, image: string) => {
     }/`,
     '',
   );
-  await UserModel.updateOne({ oauth_email }, { image: '' });
+  const deletedDocument = await UserModel.updateOne(
+    { oauth_email },
+    { image: '' },
+  );
   void s3
     .deleteObject({
       Bucket: process.env.IMAGE_BUCKET as string,
@@ -76,15 +79,17 @@ const deleteProfileImage = async (oauth_email: string, image: string) => {
     })
     .promise()
     .then(() => logger.info('delete image from S3 success!'));
+
+  return deletedDocument;
 };
 
-const updateAddress = async (prevAddress: string, newAddress: string) => {
+const updateAddress = async (oauth_email: string, address: string) => {
   try {
-    await UserModel.updateOne(
-      { address: prevAddress },
-      { address: newAddress },
-    );
-    return true;
+    const updatedDocument = await UserModel.updateOne(
+      { oauth_email },
+      { address },
+    ).then(() => logger.info(`${oauth_email} address updated!`));
+    return updatedDocument;
   } catch (e) {
     logger.error(e);
     return false;


### PR DESCRIPTION
### 🔨 작업 내용 설명
프로필 제이지 구현 완성

### 📑 구현한 내용
- AddressModal 완성
  - onSubmitHandler, onCancelHandler을 props로 받음
  - 각 함수는 선택된 dropDown에 해당하는 상태 mpaInfo를 인자로 실행됨
- Searchbar의 input을 고정할 수 있는 옵션 추가
  - 기본은 드롭다운 아이템 선택시 input을 지우도록 되어있음
  - valueState라는 props를 넘겨주면, valueState를 input의 value로 사용함
  - AddressModal에서는, address라는 상태를 넘겨주어서, 현재 선택된 드롭다운(mapInfo)의 address를 표시하도록 사용 
- Searchbar의 '동'단위만 검색하는 옵션 추가
  - onlyDong값을 주면, query string에 onlyDong을 추가
  - API에서는 onlyDong이 있으면, codeLength가 7인 친구만 찾음
- Modal 수정
  - CloseBtn 스타일 수정 -> X모양 svg img태그로 대체

### 🚧 주의 사항
- 창이 작아졌을 때, AddressModal의 버튼들이 가려짐... 해결못함
- 모달 밖에 닫혔을 때를 비활성화 시켜놓았으므로, 추후 수정 필요
> - 프로필 페이지에서 모달이 떴을 때를 router로 처리하지 않고, Profile 컴포넌트 내부에서 처리하였음
>   - background가 Map이 아니므로 이런식으로 처리하였음.
>  - 페이지로 따로 분리시, Profile 페이지의 정보는 똑같은데, 리렌더링해야함
- ProfileAddressPage로 페이지를 따로 분리
  - history, location이 꼬일 수 있으므로 명확히 라우팅 하는게 좋을듯
  - Modal의 toggleModal이 필요없어졌으므로 삭제

### 스크린 샷
![Nov-16-2021 21-52-21](https://user-images.githubusercontent.com/54357553/141988644-d19fe478-37d5-4006-85fd-841e815d1588.gif)


closes #69 
