### PR TITLE
Fix/login 로그인 기능 수정

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -45,7 +45,6 @@ const App: React.FC = () => {
               <Route path="/review" component={ReviewPage} />
               <Route path="/signin" component={SignInPage} />
               <Route path="/github/callback" component={LoadingPage} />
-              <Route path="/signup" component={SignUpPage} />
               <Route path="/profile" component={ProfilePage} />
               <Route component={NotFoundPage} />
             </Switch>
@@ -60,6 +59,7 @@ const App: React.FC = () => {
                 component={ProfileAddressPage}
               />
             )}
+            {background && <Route path="/signup" component={SignUpPage} />}
           </ContentWrapper>
         </GlobalStore>
       </ThemeProvider>

--- a/client/src/components/AddressModal/index.tsx
+++ b/client/src/components/AddressModal/index.tsx
@@ -42,7 +42,6 @@ const AddressModal: React.FC<AddressModalProps> = ({
           cancel={false}
           onClick={async () => {
             await onSubmitHandler(mapInfo);
-            onCancelHandler();
           }}
         >
           제출

--- a/client/src/components/SignUpModal/index.tsx
+++ b/client/src/components/SignUpModal/index.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
 import { useRecoilState } from 'recoil';
 
 import { authState } from '@stores/atoms';
@@ -11,14 +12,15 @@ import { IMapInfo } from '@myTypes/Map';
 const SignUpModal: React.FC = () => {
   const [auth, setAuth] = useRecoilState<IAuthInfo>(authState);
   const [history, routeHistory] = useHistoryRouter();
+  const location = useLocation();
 
   const onCancelHandler = useCallback((): void => {
-    window.location.href = process.env.REACT_APP_MAIN_URL as string;
+    routeHistory('/', {});
   }, []);
 
   const onSubmitHandler = useCallback(
     async (mapInfo: IMapInfo): Promise<void> => {
-      const [status, userInfo] = await signUpAdress(mapInfo, auth);
+      const [status, userInfo] = await signUpAdress(mapInfo, auth, location);
       isSignUp(status, userInfo, auth, setAuth, routeHistory);
     },
     [],

--- a/client/src/components/SignUpModal/index.tsx
+++ b/client/src/components/SignUpModal/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { useRecoilState } from 'recoil';
 
 import { authState } from '@stores/atoms';
@@ -12,20 +12,17 @@ const SignUpModal: React.FC = () => {
   const [auth, setAuth] = useRecoilState<IAuthInfo>(authState);
   const [history, routeHistory] = useHistoryRouter();
 
-  const onSubmitHandler = async (mapInfo: IMapInfo): Promise<void> => {
-    const [status, userInfo] = await signUpAdress(mapInfo, auth);
-    isSignUp(status, userInfo, auth, setAuth, routeHistory);
-  };
-
-  const onCancelHandler = (): void => {
+  const onCancelHandler = useCallback((): void => {
     window.location.href = process.env.REACT_APP_MAIN_URL as string;
-  };
+  }, []);
 
-  useEffect(() => {
-    if (auth.address) {
-      routeHistory('/', {});
-    }
-  }, [auth, routeHistory]);
+  const onSubmitHandler = useCallback(
+    async (mapInfo: IMapInfo): Promise<void> => {
+      const [status, userInfo] = await signUpAdress(mapInfo, auth);
+      isSignUp(status, userInfo, auth, setAuth, routeHistory);
+    },
+    [],
+  );
 
   return (
     <AdressModal

--- a/client/src/controllers/signInController.ts
+++ b/client/src/controllers/signInController.ts
@@ -40,30 +40,24 @@ const isMember = (
   auth,
   setAuth,
 ): void => {
+  const location = { pathname: '/', search: '', hash: '', state: undefined };
+
   if (status != 200) {
     alert(userInfo.message);
-    /*
-    2021-11-16
-    문혜현
-    로그인에 실패했을 시 다시 signin 페이지로 가야 하는데 아직 routeHistory 구현 못함
-    */
-    routeHistory('/signin', {});
+    routeHistory('/signin', { background: location });
+    return;
   }
 
   if (status == 200 && !userInfo.result.jwtToken) {
-    /*
-    2021-11-16
-    문혜현
-    회원가입 페이지로 routing
-    회원가입 주소를 제출할 때 db에 저장하기 위한 정보를 주기 위해서 recoil에 저장
-    */
     setAuth({
       ...auth,
       oauth_email: userInfo.result.oauthEmail,
       image: userInfo.result.image,
     });
-    routeHistory('/signup', {});
-  } else {
+    routeHistory('/signup', { background: location });
+    return;
+  }
+  if (status == 200 && userInfo.result.jwtToken) {
     /*
     2021-11-16
     문혜현
@@ -78,6 +72,7 @@ const isMember = (
       image: userInfo.result.image,
     });
     routeHistory('/', {});
+    return;
   }
 };
 

--- a/client/src/controllers/signInController.ts
+++ b/client/src/controllers/signInController.ts
@@ -54,7 +54,11 @@ const isMember = (
       oauth_email: userInfo.result.oauthEmail,
       image: userInfo.result.image,
     });
-    routeHistory('/signup', { background: location });
+    routeHistory('/signup', {
+      background: location,
+      oauth_email: userInfo.result.oauthEmail,
+      image: userInfo.result.image,
+    });
     return;
   }
   if (status == 200 && userInfo.result.jwtToken) {

--- a/client/src/controllers/signUpController.ts
+++ b/client/src/controllers/signUpController.ts
@@ -39,14 +39,10 @@ const isSignUp = (
   setAuth: SetterOrUpdater<IAuthInfo>,
   routeHistory,
 ): void => {
+  const location = { pathname: '/', search: '', hash: '', state: undefined };
   if (status != 200) {
     alert(userInfo.message);
-    /*
-    2021-11-16
-    문혜현
-    회원가입에 실패했을 시 다시 signin 페이지로 가야 하는데 아직 routeHistory 구현 못함
-    */
-    //routeHistory('/signin', {});
+    routeHistory('/signin', { background: location });
   } else {
     sessionStorage.setItem('jwt', userInfo.result.jwtToken);
     setAuth({
@@ -54,7 +50,7 @@ const isSignUp = (
       isLoggedin: true,
       address: userInfo.result.address,
     });
-    //routeHistory('/', {});
+    routeHistory('/', {});
   }
 };
 

--- a/client/src/controllers/signUpController.ts
+++ b/client/src/controllers/signUpController.ts
@@ -8,6 +8,7 @@ import { IAuthInfo } from '@myTypes/User';
 const signUpAdress = async (
   mapInfo: IMapInfo,
   auth: IAuthInfo,
+  location,
 ): Promise<[number, IAPIResult<IToken | Record<string, never>>]> => {
   const response = await fetch(
     `${process.env.REACT_APP_API_URL}/api/auth/signup`,
@@ -17,11 +18,11 @@ const signUpAdress = async (
         'Content-Type': 'application/json;charset=utf-8',
       },
       body: JSON.stringify({
-        oauthEmail: auth.oauth_email,
+        oauthEmail: location.state.oauth_email,
         address: mapInfo.address,
         code: mapInfo.code,
         center: mapInfo.center,
-        image: auth.image,
+        image: location.state.image,
       }),
     },
   );

--- a/server/src/loaders/expressLoader.ts
+++ b/server/src/loaders/expressLoader.ts
@@ -23,7 +23,7 @@ export default ({ app }: { app: Application }) => {
     const options: cors.CorsOptions = {
       origin: allowedOrigins,
     };
-    app.use(cors());
+    app.use(cors(options));
   }
 
   app.use(morgan(morganFormat, { stream }));


### PR DESCRIPTION
### 🔨 작업 내용 설명
로그인 기능 수정

### 📑 구현한 내용
- [x] 회원가입 routing 문제 해결
- [x] CORS 문제 해결
- [x] 로딩페이지에서 회원가입 모달로 넘어갈 때 recoil로 넘겨주었던 값 history 사용하기

### 🚧 주의 사항
- 검색바의 로직과 맞지 않는 부분이 있어 우선은 작동이 되도록 수정
  - 검색바는 submitHandler에서 cancelhandler도 마지막으로 동작되도록 설계되었지만 회원가입에서는 routing으로 인해 submit 할 때 cancel 동작이 들어가면 안됨
- CORS는 host와 port가 같아야 하는데 github에서는 127.0.0.1과 localhost를 자동으로 매칭해주지 못해서 생긴 문제
- recoil 대신 history.state를 사용해서 불필요한 렌더링을 줄임

[### 스크린 샷]

[issue | close] #[ISSUE_NUMBER]
