### PR TITLE
Fix: #105 - 모달창 닫힘 기능과 바깥 클릭 수정

### DIFF
--- a/client/src/components/Common/Modal/index.tsx
+++ b/client/src/components/Common/Modal/index.tsx
@@ -7,19 +7,18 @@ import {
   ChildrenWrapper,
 } from '@components/Common/Modal/index.style';
 
-import React, { useState, useEffect, useRef } from 'react';
-import { useHistory } from 'react-router-dom';
+import React, { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+import useHistoryRouter from '@hooks/useHistoryRouter';
 
 // "상위 컴포넌트에서는 클릭하면 무조건 추가한다"로 로직을 구성
 // recoil에서 전역ㅇ로 관리하는 것도 생각해 볼 수 있으려나..
 const Modal: React.FC = ({ children }) => {
-  const history = useHistory();
-  const [isActive, setIsActive] = useState(true);
-  const modalRef = useRef<HTMLDivElement>(null);
+  const [history, routeHistory] = useHistoryRouter();
+  const location = useLocation();
 
   const onClick = () => {
-    setIsActive(!isActive);
-    history.goBack();
+    routeHistory(location.state.background.pathname, {});
   };
 
   // scroll 작동 금지
@@ -33,58 +32,31 @@ const Modal: React.FC = ({ children }) => {
     };
   }, []);
 
-  // 모달창 바깥 클릭 시 모달창 없애기
-  // https://chach4.tistory.com/4 참고
-  // useEffect(() => {
-  //   const handleCloseModal = (e) => {
-  //     if (
-  //       !e.target.closest('.overlay-confirmation-submit') &&
-  //       e.target.closest('.overlay-confirmation-alert')
-  //     ) {
-  //       return;
-  //     }
-  //     if (
-  //       isActive &&
-  //       (!modalRef.current || !modalRef.current.contains(e.target))
-  //     ) {
-  //       console.log(!modalRef?.current?.contains(e.target));
-  //       console.log(e.target.closest('.modal'));
-  //       console.log(e.target.closest('body'));
-  //       console.log(e.target);
-  //       setIsActive(!isActive);
-  //       history.goBack();
-  //       if (toggleModal) {
-  //         toggleModal();
-  //       }
-  //     }
-  //   };
-
-  //   if (isActive) {
-  //     window.addEventListener('click', handleCloseModal);
-  //   } else {
-  //     window.removeEventListener('click', handleCloseModal);
-  //   }
-
-  //   return () => {
-  //     window.removeEventListener('click', handleCloseModal);
-  //   };
-  // }, [isActive]);
+  //모달창 바깥 클릭 시 모달창 없애기
+  //https://chach4.tistory.com/4 참고
+  useEffect(() => {
+    const handleCloseModal = (e) => {
+      if (e.target.className.includes('modalOverlay')) {
+        routeHistory(location.state.background.pathname, {});
+      }
+    };
+    window.addEventListener('click', handleCloseModal);
+    return () => {
+      window.removeEventListener('click', handleCloseModal);
+    };
+  });
 
   return (
-    <>
-      {isActive && (
-        <ModalOverlay>
-          <ModalWrapper ref={modalRef}>
-            <ModalCloseBtnDiv>
-              <ModalCloseBtn onClick={onClick}>
-                <ModalCloseImage />
-              </ModalCloseBtn>
-            </ModalCloseBtnDiv>
-            <ChildrenWrapper>{children}</ChildrenWrapper>
-          </ModalWrapper>
-        </ModalOverlay>
-      )}
-    </>
+    <ModalOverlay className="modalOverlay">
+      <ModalWrapper>
+        <ModalCloseBtnDiv>
+          <ModalCloseBtn onClick={onClick}>
+            <ModalCloseImage />
+          </ModalCloseBtn>
+        </ModalCloseBtnDiv>
+        <ChildrenWrapper>{children}</ChildrenWrapper>
+      </ModalWrapper>
+    </ModalOverlay>
   );
 };
 


### PR DESCRIPTION
### 🔨 작업 내용 설명
모달창 닫힘 기능과 바깥 클릭 수정

### 📑 구현한 내용
- [x] 모달창 닫힘을 클릭했을 때 background로 routing 되도록 만들기
- [x] 모달창 바깥 클릭했을 때 닫히도록 하는 것 children도 적용되도록 만들기

### 🚧 주의 사항
- 모달창 x버튼을 클릭하면 background로 routing하는 것이 뒤로가기였을 때의 문제를 해결함
- 모달창 이외의 버튼을 클릭했을 때 주소 드롭다운이 포함되어 있지 않다고 뜬 이유는 window에 걸린 click이벤트가 시작되기 전에 검색바 내부에서 재렌더링을 해서 click event의 콜백에는 포함되어 있지 않다고 나오는 게 원인이었음
- 모달창 외부를 의미하는 overlay에 className을 주어서 구분하도록 변경

[### 스크린 샷]

[issue | close] #[ISSUE_NUMBER]
