### PR TITLE
Fix: #118 - 프로필 페이지 로그인 여부 확인 구현

### DIFF
--- a/client/src/pages/ProfilePage.tsx
+++ b/client/src/pages/ProfilePage.tsx
@@ -1,6 +1,9 @@
 import Profile from '@components/Profile/index';
+import { authState } from '@stores/atoms';
+import { useRecoilState } from 'recoil';
+import useHistoryRouter from '@hooks/useHistoryRouter';
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import styled from 'styled-components';
 
 const ProfileWrapper = styled.div`
@@ -9,10 +12,22 @@ const ProfileWrapper = styled.div`
   margin: 20px 0;
 `;
 
-const ProfilePage: React.FC = () => (
-  <ProfileWrapper>
-    <Profile />
-  </ProfileWrapper>
-);
+const ProfilePage: React.FC = () => {
+  const [auth] = useRecoilState(authState);
+  const [history, routeHistory] = useHistoryRouter();
+
+  useEffect(() => {
+    if (!auth.isLoggedin) {
+      const rootLocation = { pathname: '/', state: {} };
+      routeHistory('/signin', { background: rootLocation });
+    }
+  });
+
+  return (
+    <ProfileWrapper>
+      <Profile />
+    </ProfileWrapper>
+  );
+};
 
 export default ProfilePage;


### PR DESCRIPTION
### 🔨 작업 내용 설명
로그인 여부에 따라서 안되어 있으면 '/signin'으로 라우팅

### 📑 구현한 내용
- 프로필 페이지에 useEffect를 활용해서 첫 렌더링시 auth를 recoil에서 가져옴
- 로그인이 안되어 있으면, signin으로 라우팅

### 🚧 주의 사항
- PrivateRoute가 있으면 없어도 될 기능...?

### 스크린샷
![Nov-18-2021 18-33-02](https://user-images.githubusercontent.com/54357553/142389238-524e88ea-e212-43a4-84ae-33dfbd6ffc2e.gif)

closes #118 
