### PR TITLE
Feat/refresh token 로그인에 refresh_token 넣기

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -19,6 +19,7 @@
     "axios": "^0.24.0",
     "color-hash": "^2.0.1",
     "dotenv": "^10.0.0",
+    "jwt-check-expiration": "^1.0.5",
     "proj4": "^2.7.5",
     "react": "^17.0.2",
     "react-confirm-alert": "^2.7.0",

--- a/client/src/components/Header/index.tsx
+++ b/client/src/components/Header/index.tsx
@@ -34,6 +34,7 @@ const Header: React.FC = () => {
 
   const onLogoutClick = useCallback(() => {
     sessionStorage.removeItem('jwt');
+    sessionStorage.removeItem('refreshToken');
     setAuth({
       ...auth,
       oauth_email: '',

--- a/client/src/controllers/authController.ts
+++ b/client/src/controllers/authController.ts
@@ -1,0 +1,25 @@
+import { isJwtExpired } from 'jwt-check-expiration';
+import { IToken } from '@myTypes/User';
+
+// 로그인이 이미 되어 있어서 sessionstorage에 토큰이 있다고 가정함
+const checkExpired = async () => {
+  const token = sessionStorage.getItem('jwt');
+  if (!isJwtExpired(token)) {
+    return;
+  }
+  const requestHeaders: HeadersInit = new Headers();
+  requestHeaders.set('token', sessionStorage.getItem('jwt') as string);
+  requestHeaders.set('token', sessionStorage.getItem('refreshToken') as string);
+
+  const newTokenRes = await fetch(
+    `${process.env.REACT_APP_API_URL as string}/api/auth/refresh`,
+    {
+      method: 'GET',
+      headers: requestHeaders,
+    },
+  );
+
+  const newToken: IToken = await newTokenRes.json();
+
+  sessionStorage.setItem('jwt', newToken.jwtToken);
+};

--- a/client/src/controllers/authController.ts
+++ b/client/src/controllers/authController.ts
@@ -1,15 +1,25 @@
 import { isJwtExpired } from 'jwt-check-expiration';
+
+import { IAPIResult } from '@myTypes/Common';
 import { IToken } from '@myTypes/User';
 
-// 로그인이 이미 되어 있어서 sessionstorage에 토큰이 있다고 가정함
-const checkExpired = async () => {
+/*
+2021-11-20
+문혜현
+token이 잘못되었거나 access와 refresh token이 만료된 경우로 모든 경우에 대해서 sessionStorage를 비우고 로그인 페이지로 이동시킴
+*/
+const checkExpired = async (routeHistory) => {
   const token = sessionStorage.getItem('jwt');
+
   if (!isJwtExpired(token)) {
     return;
   }
   const requestHeaders: HeadersInit = new Headers();
   requestHeaders.set('token', sessionStorage.getItem('jwt') as string);
-  requestHeaders.set('token', sessionStorage.getItem('refreshToken') as string);
+  requestHeaders.set(
+    'refreshToken',
+    sessionStorage.getItem('refreshToken') as string,
+  );
 
   const newTokenRes = await fetch(
     `${process.env.REACT_APP_API_URL as string}/api/auth/refresh`,
@@ -19,7 +29,21 @@ const checkExpired = async () => {
     },
   );
 
-  const newToken: IToken = await newTokenRes.json();
+  const newToken: IAPIResult<IToken | Record<string, never>> =
+    await newTokenRes.json();
 
-  sessionStorage.setItem('jwt', newToken.jwtToken);
+  if (newTokenRes.status !== 200) {
+    alert(newToken.message);
+    /*
+    2021-11-20
+    문혜현
+    token이 잘못되었거나 access와 refresh token이 만료된 경우로 모든 경우에 대해서 sessionStorage를 비우고 로그인 페이지로 이동시킴
+    */
+    sessionStorage.clear();
+    routeHistory('/signin', { background: { pathname: '/' } });
+  } else {
+    sessionStorage.setItem('jwt', newToken.result.jwtToken);
+  }
 };
+
+export { checkExpired };

--- a/client/src/controllers/signInController.ts
+++ b/client/src/controllers/signInController.ts
@@ -49,11 +49,6 @@ const isMember = (
   }
 
   if (status == 200 && !userInfo.result.jwtToken) {
-    setAuth({
-      ...auth,
-      oauth_email: userInfo.result.oauthEmail,
-      image: userInfo.result.image,
-    });
     routeHistory('/signup', {
       background: location,
       oauth_email: userInfo.result.oauthEmail,

--- a/client/src/controllers/signInController.ts
+++ b/client/src/controllers/signInController.ts
@@ -63,6 +63,7 @@ const isMember = (
     sessionstorage에 jwt토큰 값을 저장 && recoil update && 메인페이지로 routing
     */
     sessionStorage.setItem('jwt', userInfo.result.jwtToken);
+    sessionStorage.setItem('refreshToken', userInfo.result.refreshToken);
     setAuth({
       ...auth,
       isLoggedin: true,

--- a/client/src/controllers/signUpController.ts
+++ b/client/src/controllers/signUpController.ts
@@ -46,6 +46,7 @@ const isSignUp = (
     routeHistory('/signin', { background: location });
   } else {
     sessionStorage.setItem('jwt', userInfo.result.jwtToken);
+    sessionStorage.setItem('refreshToken', userInfo.result.refreshToken);
     setAuth({
       ...auth,
       isLoggedin: true,

--- a/client/src/controllers/signUpController.ts
+++ b/client/src/controllers/signUpController.ts
@@ -1,7 +1,7 @@
 import { SetterOrUpdater } from 'recoil';
 
 import { IAPIResult } from '@myTypes/Common';
-import { IToken } from '@myTypes/User';
+import { ISignUp } from '@myTypes/User';
 import { IMapInfo } from '@myTypes/Map';
 import { IAuthInfo } from '@myTypes/User';
 
@@ -9,7 +9,7 @@ const signUpAdress = async (
   mapInfo: IMapInfo,
   auth: IAuthInfo,
   location,
-): Promise<[number, IAPIResult<IToken | Record<string, never>>]> => {
+): Promise<[number, IAPIResult<ISignUp | Record<string, never>>]> => {
   const response = await fetch(
     `${process.env.REACT_APP_API_URL}/api/auth/signup`,
     {
@@ -27,7 +27,7 @@ const signUpAdress = async (
     },
   );
 
-  const userInfo: IAPIResult<IToken | Record<string, never>> =
+  const userInfo: IAPIResult<ISignUp | Record<string, never>> =
     await response.json();
 
   return [response.status, userInfo];
@@ -35,7 +35,7 @@ const signUpAdress = async (
 
 const isSignUp = (
   status: number,
-  userInfo: IAPIResult<IToken | Record<string, never>>,
+  userInfo: IAPIResult<ISignUp | Record<string, never>>,
   auth: IAuthInfo,
   setAuth: SetterOrUpdater<IAuthInfo>,
   routeHistory,

--- a/client/src/types/User.d.ts
+++ b/client/src/types/User.d.ts
@@ -6,6 +6,7 @@ interface IUser {
 
 interface IUserInfo extends IUser {
   jwtToken: string;
+  refreshToken: string;
   oauthEmail: string;
   address: string;
   image: string;
@@ -17,6 +18,7 @@ interface IAuthInfo extends IUser {
 
 interface IToken {
   jwtToken: string;
+  refreshToken: string;
   address: string;
 }
 

--- a/client/src/types/User.d.ts
+++ b/client/src/types/User.d.ts
@@ -19,7 +19,10 @@ interface IAuthInfo extends IUser {
 interface IToken {
   jwtToken: string;
   refreshToken: string;
+}
+
+interface ISignUp extends IToken {
   address: string;
 }
 
-export { IUserInfo, IAuthInfo, IToken };
+export { IUserInfo, IAuthInfo, IToken, ISignUp };

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -7186,6 +7186,18 @@ jsonfile@^6.0.1:
     array-includes "^3.1.3"
     object.assign "^4.1.2"
 
+jwt-check-expiration@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/jwt-check-expiration/-/jwt-check-expiration-1.0.5.tgz#4161c3090831b5279f8f0d7cb44ecb08ad852991"
+  integrity sha512-Ov2A7f/zwiZ8wvi6KG+Jeb6am1pvwgcms+HytB4GMPzrCf5UfytnlBVRh9a39Hi2v91H3aETtXHZreB8BTdbUQ==
+  dependencies:
+    jwt-decode "^2.2.0"
+
+jwt-decode@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/jwt-decode/-/jwt-decode-2.2.0.tgz#7d86bd56679f58ce6a84704a657dd392bba81a79"
+  integrity sha1-fYa9VmefWM5qhHBKZX3TkruoGnk=
+
 killable@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/killable/-/killable-1.0.1.tgz"

--- a/server/package.json
+++ b/server/package.json
@@ -27,6 +27,7 @@
     "multer": "^1.4.3",
     "pm2": "^5.1.2",
     "proj4": "^2.7.5",
+    "rand-token": "^1.0.1",
     "simplify-js": "^1.2.4",
     "tsconfig-paths": "^3.11.0",
     "uuid": "^8.3.2",

--- a/server/src/api/authController.ts
+++ b/server/src/api/authController.ts
@@ -26,6 +26,7 @@ router.post('/signin', (async (req: AuthRequest, res: Response) => {
     const isMember = await authService.isMember(oauthEmail.oauth_email);
     let userInfo = {
       jwtToken: '',
+      refreshToken: '',
       oauthEmail: '',
       address: '',
       image: '',
@@ -36,6 +37,7 @@ router.post('/signin', (async (req: AuthRequest, res: Response) => {
       userInfo = {
         ...userInfo,
         jwtToken: jwtToken.token,
+        refreshToken: jwtToken.refreshToken,
         oauthEmail: isMember.oauth_email,
         address: isMember.address,
         image: isMember.image as string,
@@ -71,14 +73,16 @@ router.post('/signup', (async (req: Request, res: Response) => {
     await authService.saveUserInfo(newUserInfo);
     const jwtToken = jwt.sign({ oauth_email: oauthEmail });
 
-    res
-      .status(200)
-      .json(
-        makeApiResponse(
-          { jwtToken: jwtToken.token, address: address },
-          '성공적으로 회원가입 되었습니다.',
-        ),
-      );
+    res.status(200).json(
+      makeApiResponse(
+        {
+          jwtToken: jwtToken.token,
+          refreshToken: jwtToken.refreshToken,
+          address: address,
+        },
+        '성공적으로 회원가입 되었습니다.',
+      ),
+    );
   } catch (error) {
     const err = error as Error;
     logger.error(err.message);

--- a/server/src/config/index.ts
+++ b/server/src/config/index.ts
@@ -17,5 +17,9 @@ export default {
   client_id: process.env.CLIENT_ID || '',
   client_secret: process.env.CLIENT_SECRET || '',
   jwt_secret: process.env.JWT_SECRET || '',
+  jwt_refresh_secret: process.env.JWT_REFRESH_SECRET || '',
   jwt_algorithm: process.env.JWT_ALGORITHM || '',
+  jwt_refresh_algorithm: process.env.JWT_REFRESH_ALGORITHM || '',
+  jwt_expire: process.env.JWT_EXPIRE || '',
+  jwt_refresh_expire: process.env.JWT_REFRESH_EXPIRE || '',
 };

--- a/server/src/config/secretKey.ts
+++ b/server/src/config/secretKey.ts
@@ -10,7 +10,16 @@ const jwtConfig: Config = {
   secretKey: config.jwt_secret,
   options: {
     algorithm: config.jwt_algorithm as jwt.Algorithm,
+    expiresIn: config.jwt_expire,
   },
 };
 
-export default jwtConfig;
+const jwtRefreshConfig: Config = {
+  secretKey: config.jwt_refresh_secret,
+  options: {
+    algorithm: config.jwt_refresh_algorithm as jwt.Algorithm,
+    expiresIn: config.jwt_refresh_expire,
+  },
+};
+
+export { jwtConfig, jwtRefreshConfig };

--- a/server/src/middlewares/auth.ts
+++ b/server/src/middlewares/auth.ts
@@ -25,7 +25,9 @@ const checkToken = (
     logger.error('유효기간이 만료되었습니다.');
     return res
       .status(500)
-      .json(makeApiResponse({}, '유효기간 만료되었습니다.'));
+      .json(
+        makeApiResponse({ token: TOKEN_EXPIRED }, '유효기간 만료되었습니다.'),
+      );
   }
   if (user === TOKEN_INVALID) {
     logger.error('유효하지 않은 토큰입니다.');

--- a/server/src/middlewares/auth.ts
+++ b/server/src/middlewares/auth.ts
@@ -1,12 +1,11 @@
-import express, { Response, NextFunction } from 'express';
+import { Response, NextFunction } from 'express';
 import logger from '@loaders/loggerLoader';
 import jwt from '@services/jwtService';
 import { makeApiResponse } from '@utils/index';
 import { AuthMiddleRequest } from '@myTypes/User';
 import { JwtPayload } from 'jsonwebtoken';
-
-const TOKEN_EXPIRED = -3;
-const TOKEN_INVALID = -2;
+import { AuthError } from '@utils/authErrorEnum';
+import { authErrCheck } from '@utils/authError';
 
 const checkToken = (
   req: AuthMiddleRequest,
@@ -21,24 +20,17 @@ const checkToken = (
   }
 
   const user = jwt.verify(token);
-  if (user === TOKEN_EXPIRED) {
+
+  if (user == AuthError.TOKEN_EXPIRED) {
     logger.error('유효기간이 만료되었습니다.');
-    return res
-      .status(500)
-      .json(
-        makeApiResponse({ token: TOKEN_EXPIRED }, '유효기간 만료되었습니다.'),
-      );
-  }
-  if (user === TOKEN_INVALID) {
-    logger.error('유효하지 않은 토큰입니다.');
-    return res
-      .status(500)
-      .json(makeApiResponse({}, '유효하지 않은 토큰입니다.'));
+    return next();
   }
 
-  if ((user as JwtPayload).oauth_email === undefined) {
-    logger.error('잘못된 토큰입니다.');
-    return res.status(500).json(makeApiResponse({}, '잘못된 토큰입니다.'));
+  if (
+    user === AuthError.TOKEN_INVALID ||
+    (user as JwtPayload).oauth_email === undefined
+  ) {
+    return authErrCheck(user, res);
   }
 
   req.id = (user as JwtPayload).oauth_email as string;

--- a/server/src/services/jwtService.ts
+++ b/server/src/services/jwtService.ts
@@ -1,5 +1,6 @@
 import jwt from 'jsonwebtoken';
 import jwtConfig from '@config/secretKey';
+import randToken from 'rand-token';
 
 const TOKEN_EXPIRED = -3;
 const TOKEN_INVALID = -2;
@@ -9,8 +10,9 @@ export default {
     const payload = {
       oauth_email: user.oauth_email,
     };
-    const token: { token: string } = {
+    const token: { token: string; refreshToken: string } = {
       token: jwt.sign(payload, jwtConfig.secretKey, jwtConfig.options),
+      refreshToken: randToken.uid(16),
     };
     return token;
   },

--- a/server/src/services/jwtService.ts
+++ b/server/src/services/jwtService.ts
@@ -1,8 +1,6 @@
 import jwt from 'jsonwebtoken';
 import { jwtConfig, jwtRefreshConfig } from '@config/secretKey';
-
-const TOKEN_EXPIRED = -3;
-const TOKEN_INVALID = -2;
+import { AuthError } from '@utils/authErrorEnum';
 
 export default {
   sign: (user: { oauth_email: string }) => {
@@ -30,11 +28,11 @@ export default {
     } catch (err) {
       const errMsg = (err as Error).message;
       if (errMsg === 'jwt expired') {
-        return TOKEN_EXPIRED;
+        return AuthError.TOKEN_EXPIRED;
       } else if (errMsg === 'invalid token') {
-        return TOKEN_INVALID;
+        return AuthError.TOKEN_INVALID;
       } else {
-        return TOKEN_INVALID;
+        return AuthError.TOKEN_INVALID;
       }
     }
     return decoded;

--- a/server/src/services/jwtService.ts
+++ b/server/src/services/jwtService.ts
@@ -1,6 +1,5 @@
 import jwt from 'jsonwebtoken';
-import jwtConfig from '@config/secretKey';
-import randToken from 'rand-token';
+import { jwtConfig, jwtRefreshConfig } from '@config/secretKey';
 
 const TOKEN_EXPIRED = -3;
 const TOKEN_INVALID = -2;
@@ -12,14 +11,22 @@ export default {
     };
     const token: { token: string; refreshToken: string } = {
       token: jwt.sign(payload, jwtConfig.secretKey, jwtConfig.options),
-      refreshToken: randToken.uid(16),
+      refreshToken: jwt.sign(
+        payload,
+        jwtRefreshConfig.secretKey,
+        jwtRefreshConfig.options,
+      ),
     };
     return token;
   },
-  verify: (token: string) => {
+  verify: (token: string, kind = 'jwt') => {
     let decoded: string | jwt.JwtPayload;
     try {
-      decoded = jwt.verify(token, jwtConfig.secretKey);
+      if (kind === 'jwt') {
+        decoded = jwt.verify(token, jwtConfig.secretKey);
+      } else {
+        decoded = jwt.verify(token, jwtRefreshConfig.secretKey);
+      }
     } catch (err) {
       const errMsg = (err as Error).message;
       if (errMsg === 'jwt expired') {

--- a/server/src/utils/authError.ts
+++ b/server/src/utils/authError.ts
@@ -1,0 +1,21 @@
+import express, { Response, NextFunction } from 'express';
+import { JwtPayload } from 'jsonwebtoken';
+import logger from '@loaders/loggerLoader';
+import { makeApiResponse } from '@utils/index';
+import { AuthError } from '@utils/authErrorEnum';
+
+const authErrCheck = (user: string | -3 | -2 | JwtPayload, res: Response) => {
+  if (user === AuthError.TOKEN_INVALID) {
+    logger.error('유효하지 않은 토큰입니다.');
+    return res
+      .status(500)
+      .json(makeApiResponse({}, '유효하지 않은 토큰입니다.'));
+  }
+
+  if ((user as JwtPayload).oauth_email === undefined) {
+    logger.error('잘못된 토큰입니다.');
+    return res.status(500).json(makeApiResponse({}, '잘못된 토큰입니다.'));
+  }
+};
+
+export { authErrCheck };

--- a/server/src/utils/authErrorEnum.ts
+++ b/server/src/utils/authErrorEnum.ts
@@ -1,0 +1,6 @@
+enum AuthError {
+  TOKEN_EXPIRED = -3,
+  TOKEN_INVALID = -2,
+}
+
+export { AuthError };

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -3304,6 +3304,11 @@ queue-microtask@^1.2.2:
   resolved "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
+rand-token@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/rand-token/-/rand-token-1.0.1.tgz#a47fdfd94894cc349d74234403c4b24624733c58"
+  integrity sha512-Zri5SfJmEzBJ3IexFdigvPSCamslJ7UjLkUn0tlgH7COJvaUr5V7FyUYgKifEMTw7gFO8ZLcWjcU+kq8akipzg==
+
 range-parser@~1.2.1:
   version "1.2.1"
   resolved "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz"


### PR DESCRIPTION
### 🔨 작업 내용 설명
로그인에 refresh_token 넣기

### 📑 구현한 내용

- [x] refresh token 발급
- [x] token 유효기간 만료 시 재발급
- [x] refresh token 예외처리
- [x] 리팩토링

### 🚧 주의 사항

middleware에서 return res를 하지 않고 바로 res만 하면 early return처럼 되는 것이 아니라 계속해서 함수가 실행되었다. 그래서 꼭 return을 주어 early return을 해주어야 한다.
에러처리를 하면서 조건이 겹치는 부분이 존재해서 원하지 않는 조건문이 걸리는 경우가 있었다. if문의 순서를 통해 해결했는데 잘한 건지는 모르겠다.

[### 스크린 샷]

[issue | close] #[ISSUE_NUMBER]
