### PR TITLE
Feat/hashtag 해시태그 기능추가 / 자잘한 작업

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -19,6 +19,7 @@
     "axios": "^0.24.0",
     "color-hash": "^2.0.1",
     "dotenv": "^10.0.0",
+    "jwt-check-expiration": "^1.0.5",
     "proj4": "^2.7.5",
     "react": "^17.0.2",
     "react-confirm-alert": "^2.7.0",

--- a/client/src/components/Common/BarRate/index.style.tsx
+++ b/client/src/components/Common/BarRate/index.style.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 const BaseDiv = styled.div`
   position: relative;
   display: flex;
-  width: 100%;
+  width: 80%;
   justify-content: space-between;
   align-items: center;
 `;
@@ -27,10 +27,11 @@ const RateCategoryTitle = styled.span`
 `;
 
 const RateCategoryUnit = styled.div`
-  width: 80%;
+  width: 90%;
   height: 6px;
   display: flex;
   align-items: center;
+  justify-content: space-between;
   position: relative;
   background-color: ${(props) => props.theme.colors.lightgrey};
   border-radius: 5px;
@@ -38,9 +39,6 @@ const RateCategoryUnit = styled.div`
 `;
 
 const RateCategoryBar = styled.span<{ rate: number }>`
-  position: absolute;
-  left: 0px;
-  top: 0px;
   height: 6px;
   width: ${(props) => props.rate * 20}%;
   background-color: ${(props) => props.theme.colors.green};
@@ -50,7 +48,7 @@ const RateCategoryBar = styled.span<{ rate: number }>`
 
 const RateCategoryNum = styled(RateCategoryTitle)`
   position: relative;
-  left: 105%;
+  left: 25px;
 `;
 
 export {

--- a/client/src/components/Common/HashTag/index.style.tsx
+++ b/client/src/components/Common/HashTag/index.style.tsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 
 const HashTag = styled.span`
+  height: 10px;
   display: inline-block;
   border: 1px solid ${(props) => props.theme.colors.green};
   color: ${(props) => props.theme.colors.darkblue};

--- a/client/src/components/Common/ReviewContent/index.style.tsx
+++ b/client/src/components/Common/ReviewContent/index.style.tsx
@@ -70,7 +70,6 @@ const ContentBottomDiv = styled(BaseDiv)`
 const RateDiv = styled(BaseDiv)`
   flex-direction: column;
   width: 100%;
-  padding-left: 60px;
   border-bottom: none;
 `;
 

--- a/client/src/components/Common/ReviewContent/index.tsx
+++ b/client/src/components/Common/ReviewContent/index.tsx
@@ -37,7 +37,38 @@ const RegionContent: React.FC<IProps> = (props: IProps) => {
   const [hasMore, setHasMore] = useState<boolean>(true);
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const observer = useRef<null | IntersectionObserver>(null);
-  const today = new Date().getTime();
+  const NUMBER_OF_DATA_PER_PAGE = 3;
+
+  const showDate = (createdAt: Date) => {
+    const now = new Date();
+    const post = new Date(createdAt);
+    const yearDiff = now.getUTCFullYear() - post.getUTCFullYear();
+    if (yearDiff < 1) {
+      const monthDiff = now.getUTCMonth() - post.getUTCMonth();
+      if (monthDiff < 1) {
+        const dateDiff = now.getUTCDate() - post.getUTCDate();
+        if (dateDiff < 1) {
+          const hourDiff = now.getUTCHours() - post.getUTCHours();
+          if (hourDiff < 1) {
+            const minuteDiff = now.getUTCMinutes() - post.getUTCMinutes();
+            if (minuteDiff < 1) {
+              return `방금전`;
+            } else {
+              return `${minuteDiff} 분전`;
+            }
+          } else {
+            return `${hourDiff} 시간전`;
+          }
+        } else {
+          return `${dateDiff} 일전`;
+        }
+      } else {
+        return `${monthDiff} 달전`;
+      }
+    } else {
+      return `${yearDiff} 년전`;
+    }
+  };
 
   const fetchData = useCallback(async () => {
     setIsLoading(true);
@@ -94,13 +125,7 @@ const RegionContent: React.FC<IProps> = (props: IProps) => {
                   ).toFixed(1)}
                 />
                 <ContentTopTextDiv>
-                  <DateText>
-                    {Math.floor(
-                      (today - new Date(content.createdAt).getTime()) /
-                        (1000 * 3600 * 24),
-                    )}{' '}
-                    일전
-                  </DateText>
+                  <DateText>{showDate(content.createdAt)}</DateText>
                   <UserText>{content.user}</UserText>
                 </ContentTopTextDiv>
               </ContentTopDiv>

--- a/client/src/components/Common/StarRate/index.style.tsx
+++ b/client/src/components/Common/StarRate/index.style.tsx
@@ -3,7 +3,6 @@ import styled from 'styled-components';
 const BaseDiv = styled.div`
   position: relative;
   display: flex;
-  width: 100%;
   justify-content: space-between;
   align-items: center;
   line-height: 40px;
@@ -22,7 +21,7 @@ const RateSpanText = styled.span<{ isLarge: boolean }>`
 const RateStarDiv = styled(RateNumStarDiv)`
   width: fit-content;
   position: relative;
-  overflow: hidden;
+  overflow: visible;
   box-sizing: content-box;
 `;
 
@@ -38,6 +37,7 @@ const RateStarFillDiv = styled.div<{ rate: number }>`
   color: gold;
   padding: 0;
   position: relative;
+  bottom: 2px;
   z-index: 1;
   display: flex;
   width: ${(props) => props.rate * 20}%;

--- a/client/src/components/Header/index.style.tsx
+++ b/client/src/components/Header/index.style.tsx
@@ -89,10 +89,11 @@ const SignInBtn = styled.button`
   height: 40px;
   text-align: center;
   cursor: pointer;
+  color: ${(props) => props.theme.colors.lightgreen};
 
   &:hover {
-    background: ${(props) => props.theme.colors.lightgreen};
-    color: ${(props) => props.theme.colors.white};
+    color: ${(props) => props.theme.colors.green};
+    border: 1px solid ${(props) => props.theme.colors.green};
   }
 `;
 
@@ -103,8 +104,8 @@ const ReviewButton = styled(SignInBtn)`
   margin-right: 10px;
 
   &:hover {
-    background: ${(props) => props.theme.colors.white};
-    color: ${(props) => props.theme.colors.lightgreen};
+    background: ${(props) => props.theme.colors.green};
+    color: ${(props) => props.theme.colors.white};
   }
 `;
 

--- a/client/src/components/Header/index.tsx
+++ b/client/src/components/Header/index.tsx
@@ -34,6 +34,7 @@ const Header: React.FC = () => {
 
   const onLogoutClick = useCallback(() => {
     sessionStorage.removeItem('jwt');
+    sessionStorage.removeItem('refreshToken');
     setAuth({
       ...auth,
       oauth_email: '',

--- a/client/src/components/Header/index.tsx
+++ b/client/src/components/Header/index.tsx
@@ -17,8 +17,6 @@ import {
   ColorBar,
   ProfileImage,
 } from './index.style';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faUserCircle } from '@fortawesome/free-solid-svg-icons';
 
 import React, { useEffect, useState, useCallback } from 'react';
 import { useLocation } from 'react-router-dom';
@@ -68,16 +66,6 @@ const Header: React.FC = () => {
                     className={`${clickedLinkBtnId === '/' && 'link-selected'}`}
                   >
                     동네 지도
-                  </LinkBtn>
-                </Menu>
-                <Menu>
-                  <LinkBtn
-                    onClick={() => routeHistory('/review')}
-                    className={`${
-                      clickedLinkBtnId === '/review' && 'link-selected'
-                    }`}
-                  >
-                    동네 후기
                   </LinkBtn>
                 </Menu>
                 <Menu>

--- a/client/src/components/Map/index.tsx
+++ b/client/src/components/Map/index.tsx
@@ -64,6 +64,8 @@ const MapComponent: React.FC<IProps> = ({
   const [markers, setMarkers] = useState(Array<kakao.maps.CustomOverlay>());
   const [polygons, setPolygons] = useState(Array<IPolygon>());
 
+  const [browserSize, setBrowserSize] = useState([0, 0]);
+
   const moveTo = (to: IMapInfo) => {
     if (map === null) {
       return;
@@ -231,13 +233,24 @@ const MapComponent: React.FC<IProps> = ({
     };
   }, [polygons, markers, openSidebar, updateSidebarRate]);
 
+  useEffect(() => {
+    const updateSize = () => {
+      setBrowserSize([window.innerWidth, window.innerHeight]);
+    };
+
+    window.addEventListener('resize', updateSize);
+    return window.removeEventListener('resize', updateSize);
+  }, []);
+
   return (
-    <MapWrapper ref={mapWrapper}>
-      <SearchbarWrapper>
-        <Searchbar onClickHandler={moveTo} />
-      </SearchbarWrapper>
+    <>
+      <MapWrapper ref={mapWrapper}>
+        <SearchbarWrapper>
+          <Searchbar onClickHandler={moveTo} />
+        </SearchbarWrapper>
+      </MapWrapper>
       <CenterMarker />
-    </MapWrapper>
+    </>
   );
 };
 

--- a/client/src/components/ReviewModal/alertStyle.css
+++ b/client/src/components/ReviewModal/alertStyle.css
@@ -1,0 +1,15 @@
+.react-confirm-alert-body {
+  text-align: center;
+}
+
+.react-confirm-alert-button-group {
+  justify-content: center;
+}
+
+.react-confirm-alert-button-group > button {
+  background: #33ab74;
+}
+
+.react-confirm-alert-button-group > button:hover {
+  background: #70c49d;
+}

--- a/client/src/components/ReviewModal/index.style.tsx
+++ b/client/src/components/ReviewModal/index.style.tsx
@@ -35,6 +35,7 @@ const TextInput = styled.textarea`
   margin: auto;
   padding: 0 30px 50px 0px;
   border: 1px solid ${(props) => props.theme.colors.lightgrey};
+  border-radius: 5px;
   resize: none;
   line-height: 24px;
 `;
@@ -61,6 +62,11 @@ const SubmitBtn = styled.button`
   color: ${(props) => props.theme.colors.white};
   background-color: ${(props) => props.theme.colors.lightgreen};
   cursor: pointer;
+  border-radius: 10px;
+
+  :hover {
+    background-color: ${(props) => props.theme.colors.green};
+  }
 `;
 
 export {

--- a/client/src/components/ReviewModal/index.style.tsx
+++ b/client/src/components/ReviewModal/index.style.tsx
@@ -39,6 +39,15 @@ const TextInput = styled.textarea`
   line-height: 24px;
 `;
 
+const HashTagWrapper = styled.div`
+  width: 70%;
+  margin-top: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+`;
+
 const SubmitDiv = styled(BaseDiv)`
   margin-top: 15px;
 `;
@@ -54,4 +63,12 @@ const SubmitBtn = styled.button`
   cursor: pointer;
 `;
 
-export { TitleDiv, StarRateDiv, TextAreaDiv, TextInput, SubmitDiv, SubmitBtn };
+export {
+  TitleDiv,
+  StarRateDiv,
+  TextAreaDiv,
+  TextInput,
+  HashTagWrapper,
+  SubmitDiv,
+  SubmitBtn,
+};

--- a/client/src/components/ReviewModal/index.tsx
+++ b/client/src/components/ReviewModal/index.tsx
@@ -6,21 +6,22 @@ import {
   StarRateDiv,
   TextAreaDiv,
   TextInput,
+  HashTagWrapper,
   SubmitDiv,
   SubmitBtn,
 } from './index.style';
 import DynamicStarRateDiv from '@components/Common/DynamicStarRate';
 import { Category } from '@utils/enum';
-import { submitReview } from '@controllers/reviewController';
+import { submitReview, parseHashtags } from '@controllers/reviewController';
 import { ICategories, IReviewSubmit } from '@myTypes/Review';
 import { useRecoilValue } from 'recoil';
 import { authState } from '@stores/atoms';
+import { HashTag } from '@components/Common/HashTag/index.style';
 
 import React, { useCallback, useState } from 'react';
 import useHistoryRouter from '@hooks/useHistoryRouter';
 
 const ReviewModal: React.FC = () => {
-  const DEFAULT_ADDRESS = '대전광역시 서구 탄방동';
   const [history, routeHistory] = useHistoryRouter();
   const [reviewData, setReviewData] = useState<IReviewSubmit>({
     address: useRecoilValue(authState).address,
@@ -32,11 +33,18 @@ const ReviewModal: React.FC = () => {
       food: 1,
       entertainment: 1,
     },
+    hashtags: [],
   });
 
   const setText = useCallback((text: string) => {
     setReviewData((prevData) => {
       return { ...prevData, text: text.slice(0, 400) };
+    });
+  }, []);
+
+  const setHashtags = useCallback((text: string) => {
+    setReviewData((prevData) => {
+      return { ...prevData, hashtags: parseHashtags(text.slice(0, 400)) };
     });
   }, []);
 
@@ -83,7 +91,10 @@ const ReviewModal: React.FC = () => {
           placeholder="후기를 작성해주세요.(선택, 400자 이내)"
           rows={3}
           cols={20}
-          onChange={(e) => setText(e.target.value)}
+          onChange={(e) => {
+            setText(e.target.value);
+            setHashtags(e.target.value);
+          }}
           value={reviewData.text}
         ></TextInput>
         <p
@@ -97,6 +108,11 @@ const ReviewModal: React.FC = () => {
           {reviewData.text.length} / 400
         </p>
       </TextAreaDiv>
+      <HashTagWrapper>
+        {reviewData.hashtags?.map((h) => (
+          <HashTag key={h}>{h}</HashTag>
+        ))}
+      </HashTagWrapper>
       <SubmitDiv>
         <SubmitBtn onClick={submitHandler}>제출하기</SubmitBtn>
       </SubmitDiv>

--- a/client/src/components/ReviewModal/index.tsx
+++ b/client/src/components/ReviewModal/index.tsx
@@ -87,6 +87,17 @@ const ReviewModal: React.FC = () => {
       </TitleDiv>
       <StarRateDiv>{RatingStars}</StarRateDiv>
       <TextAreaDiv>
+        <p
+          style={{
+            position: 'absolute',
+            right: '75px',
+            top: '-35px',
+            color: reviewData.text.length < 400 ? 'grey' : 'red',
+            marginRight: '10px',
+          }}
+        >
+          {reviewData.text.length} / 400
+        </p>
         <TextInput
           placeholder="후기를 작성해주세요.(선택, 400자 이내)"
           rows={3}
@@ -97,16 +108,6 @@ const ReviewModal: React.FC = () => {
           }}
           value={reviewData.text}
         ></TextInput>
-        <p
-          style={{
-            position: 'absolute',
-            right: '75px',
-            bottom: '-10px',
-            color: 'red',
-          }}
-        >
-          {reviewData.text.length} / 400
-        </p>
       </TextAreaDiv>
       <HashTagWrapper>
         {reviewData.hashtags?.map((h) => (

--- a/client/src/components/Sidebar/index.style.tsx
+++ b/client/src/components/Sidebar/index.style.tsx
@@ -77,23 +77,29 @@ const SpanReviewTitle = styled(SpanTitle)`
 `;
 
 const RateDiv = styled(BaseDiv)`
+  display: flex;
   flex-direction: column;
   width: 100%;
-  padding-left: 60px;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 0;
 `;
 
 const HashTagDiv = styled(BaseDiv)`
   position: relative;
   width: 100%;
-  padding: 10px 55px;
+  padding: 10px 10px;
   flex-wrap: wrap;
-  justify-content: start;
+  justify-content: center;
 `;
 
 const HashTagNo = styled.div`
   width: 100%;
+  height: 28px;
+  display: flex;
   color: ${(props) => props.theme.colors.lightgrey};
-  text-align: center;
+  align-items: center;
+  justify-content: center;
 `;
 
 const MenuBarDiv = styled(BaseDiv)`

--- a/client/src/components/Sidebar/index.style.tsx
+++ b/client/src/components/Sidebar/index.style.tsx
@@ -90,6 +90,12 @@ const HashTagDiv = styled(BaseDiv)`
   justify-content: start;
 `;
 
+const HashTagNo = styled.div`
+  width: 100%;
+  color: ${(props) => props.theme.colors.lightgrey};
+  text-align: center;
+`;
+
 const MenuBarDiv = styled(BaseDiv)`
   position: relative;
   width: 100%;
@@ -137,6 +143,7 @@ export {
   SpanReviewTitle,
   RateDiv,
   HashTagDiv,
+  HashTagNo,
   MenuBarDiv,
   Menu,
   ReviewContentDiv,

--- a/client/src/components/Sidebar/index.tsx
+++ b/client/src/components/Sidebar/index.tsx
@@ -9,6 +9,7 @@ import {
   SpanTitle,
   RateDiv,
   HashTagDiv,
+  HashTagNo,
   MenuBarDiv,
   Menu,
   SidebarBottomDiv,
@@ -26,7 +27,7 @@ export interface IProps {
   rateData: IMapInfo;
   contentsData: IReviewContent[];
   setContentsData: Dispatch<SetStateAction<IReviewContent[]>>;
-  hashTagData: string[];
+  hashTagData: Map<string, number>;
   closeSidebar: () => void;
 }
 
@@ -34,6 +35,14 @@ const Sidebar: React.FC<IProps> = (props: IProps) => {
   const [selectedMenu, setSelectedMenu] = useState('review');
 
   const total = calcTotal(props.rateData.categories) / props.rateData.count;
+
+  const filterTop5Hashtags = (hashtags: Map<string, number>) =>
+    Array.from(hashtags.entries())
+      .sort((a, b) => a[1] - b[1])
+      .map((hashtag) => hashtag[0])
+      .slice(0, 5);
+
+  React.useEffect(() => console.log(props.hashTagData), []);
 
   return (
     <Layout className={`${props.sidebar ? 'open' : ''}`}>
@@ -50,7 +59,15 @@ const Sidebar: React.FC<IProps> = (props: IProps) => {
         />
       </RateDiv>
       <HashTagDiv>
-        <HashTagList hashTags={props.hashTagData} />
+        {Object.keys(props.hashTagData).length ? (
+          <HashTagList
+            hashTags={filterTop5Hashtags(
+              new Map(Object.entries(props.hashTagData)),
+            )}
+          />
+        ) : (
+          <HashTagNo>아직 해시태그가 없어요...</HashTagNo>
+        )}
       </HashTagDiv>
       <MenuBarDiv>
         <Menu

--- a/client/src/components/Sidebar/index.tsx
+++ b/client/src/components/Sidebar/index.tsx
@@ -42,8 +42,6 @@ const Sidebar: React.FC<IProps> = (props: IProps) => {
       .map((hashtag) => hashtag[0])
       .slice(0, 5);
 
-  React.useEffect(() => console.log(props.hashTagData), []);
-
   return (
     <Layout className={`${props.sidebar ? 'open' : ''}`}>
       <TitleDiv>

--- a/client/src/components/Sidebar/index.tsx
+++ b/client/src/components/Sidebar/index.tsx
@@ -45,7 +45,7 @@ const Sidebar: React.FC<IProps> = (props: IProps) => {
   return (
     <Layout className={`${props.sidebar ? 'open' : ''}`}>
       <TitleDiv>
-        <SpanBackArrow onClick={() => props.closeSidebar()}>❮</SpanBackArrow>
+        <SpanBackArrow onClick={() => props.closeSidebar()}>❯</SpanBackArrow>
         <SpanTitle>{props.rateData.address}</SpanTitle>
         <EmptySpan></EmptySpan>
       </TitleDiv>

--- a/client/src/controllers/authController.ts
+++ b/client/src/controllers/authController.ts
@@ -1,0 +1,25 @@
+import { isJwtExpired } from 'jwt-check-expiration';
+import { IToken } from '@myTypes/User';
+
+// 로그인이 이미 되어 있어서 sessionstorage에 토큰이 있다고 가정함
+const checkExpired = async () => {
+  const token = sessionStorage.getItem('jwt');
+  if (!isJwtExpired(token)) {
+    return;
+  }
+  const requestHeaders: HeadersInit = new Headers();
+  requestHeaders.set('token', sessionStorage.getItem('jwt') as string);
+  requestHeaders.set('token', sessionStorage.getItem('refreshToken') as string);
+
+  const newTokenRes = await fetch(
+    `${process.env.REACT_APP_API_URL as string}/api/auth/refresh`,
+    {
+      method: 'GET',
+      headers: requestHeaders,
+    },
+  );
+
+  const newToken: IToken = await newTokenRes.json();
+
+  sessionStorage.setItem('jwt', newToken.jwtToken);
+};

--- a/client/src/controllers/authController.ts
+++ b/client/src/controllers/authController.ts
@@ -1,15 +1,25 @@
 import { isJwtExpired } from 'jwt-check-expiration';
+
+import { IAPIResult } from '@myTypes/Common';
 import { IToken } from '@myTypes/User';
 
-// 로그인이 이미 되어 있어서 sessionstorage에 토큰이 있다고 가정함
-const checkExpired = async () => {
+/*
+2021-11-20
+문혜현
+token이 잘못되었거나 access와 refresh token이 만료된 경우로 모든 경우에 대해서 sessionStorage를 비우고 로그인 페이지로 이동시킴
+*/
+const checkExpired = async (routeHistory) => {
   const token = sessionStorage.getItem('jwt');
+
   if (!isJwtExpired(token)) {
     return;
   }
   const requestHeaders: HeadersInit = new Headers();
   requestHeaders.set('token', sessionStorage.getItem('jwt') as string);
-  requestHeaders.set('token', sessionStorage.getItem('refreshToken') as string);
+  requestHeaders.set(
+    'refreshToken',
+    sessionStorage.getItem('refreshToken') as string,
+  );
 
   const newTokenRes = await fetch(
     `${process.env.REACT_APP_API_URL as string}/api/auth/refresh`,
@@ -19,7 +29,21 @@ const checkExpired = async () => {
     },
   );
 
-  const newToken: IToken = await newTokenRes.json();
+  const newToken: IAPIResult<IToken | Record<string, never>> =
+    await newTokenRes.json();
 
-  sessionStorage.setItem('jwt', newToken.jwtToken);
+  if (newTokenRes.status !== 200) {
+    alert(newToken.message);
+    /*
+    2021-11-20
+    문혜현
+    token이 잘못되었거나 access와 refresh token이 만료된 경우로 모든 경우에 대해서 sessionStorage를 비우고 로그인 페이지로 이동시킴
+    */
+    sessionStorage.clear();
+    routeHistory('/signin', { background: { pathname: '/' } });
+  } else {
+    sessionStorage.setItem('jwt', newToken.result.jwtToken);
+  }
 };
+
+export { checkExpired };

--- a/client/src/controllers/markerController.ts
+++ b/client/src/controllers/markerController.ts
@@ -31,7 +31,6 @@ const markerEl = (rateData: IMapInfo) => {
   const smallestRegion = region[region.length - 1];
 
   wrapper.dataset.address = address;
-  rateData.hashtags = Object.fromEntries(rateData.hashtags.entries());
   wrapper.dataset.rateData = JSON.stringify(rateData);
   wrapper.innerHTML = `
     <div class="title">
@@ -151,6 +150,7 @@ const createMarkers = (rateDatas: IMapInfo[]): kakao.maps.CustomOverlay[] => {
       position: new kakao.maps.LatLng(...center),
     });
 
+    rateData.hashtags = Object.fromEntries(rateData.hashtags.entries());
     const defaultMarker = markerEl(rateData);
     const largeMarker = largeMarkerEl(rateData);
 
@@ -222,7 +222,12 @@ const LFURates = async (
 
   if (cache.has(key)) {
     const rateData = cache.get(key);
-    if (rateData) rateData.hitCount++;
+    if (rateData) {
+      rateData.forEach((r, i) => {
+        rateData[i] = { ...r, hashtags: new Map(Object.entries(r.hashtags)) };
+      });
+      rateData.hitCount++;
+    }
     return rateData;
   } else {
     const rates = (await requestRates(scale, region)) as IMapInfo[] & {

--- a/client/src/controllers/markerController.ts
+++ b/client/src/controllers/markerController.ts
@@ -31,6 +31,7 @@ const markerEl = (rateData: IMapInfo) => {
   const smallestRegion = region[region.length - 1];
 
   wrapper.dataset.address = address;
+  rateData.hashtags = Object.fromEntries(rateData.hashtags.entries());
   wrapper.dataset.rateData = JSON.stringify(rateData);
   wrapper.innerHTML = `
     <div class="title">
@@ -114,6 +115,7 @@ const regionToRates = (region): IMapInfo => {
       food,
       entertainment,
     },
+    hashtags: new Map(),
   };
 };
 
@@ -130,9 +132,12 @@ const requestRates = async (
       }
       throw Error('요청 실패');
     })
-    .then((res: IAPIResult<IMapInfo[]>) => {
-      return res.result;
-    })
+    .then((res: IAPIResult<IMapInfo[]>) =>
+      res.result.map((r) => ({
+        ...r,
+        hashtags: new Map(Object.entries(r.hashtags)),
+      })),
+    )
     .catch((err) => {
       console.error(err);
       return [];

--- a/client/src/controllers/reviewController.ts
+++ b/client/src/controllers/reviewController.ts
@@ -22,11 +22,7 @@ const submitReview = (
             method: 'POST',
             headers: requestHeaders,
             body: JSON.stringify(data),
-          })
-            .then((res) => res.json())
-            .then((res) => {
-              console.log(res);
-            });
+          }).then((res) => res.json());
           routeHistory('/', {});
         },
       },
@@ -69,4 +65,9 @@ const fetchContentData = async (
     });
 };
 
-export { submitReview, fetchContentData };
+const parseHashtags = (text: string) =>
+  Array.from(text.matchAll(/#[^#\s]*/g)).map((hashtag) =>
+    hashtag[0].replace('#', ''),
+  );
+
+export { submitReview, fetchContentData, parseHashtags };

--- a/client/src/controllers/reviewController.ts
+++ b/client/src/controllers/reviewController.ts
@@ -1,7 +1,9 @@
 import { IAPIResult } from '@myTypes/Common';
 import { IReviewContent, IReviewSubmit } from '@myTypes/Review';
 import { confirmAlert } from 'react-confirm-alert';
+
 import 'react-confirm-alert/src/react-confirm-alert.css';
+import '@components/ReviewModal/alertStyle.css';
 
 const submitReview = (
   data: IReviewSubmit,
@@ -12,8 +14,7 @@ const submitReview = (
     buttons: [
       {
         label: '제출',
-        className: 'overlay-confirmation-submit',
-        onClick: async () => {
+        onClick: () => {
           const requestHeaders: HeadersInit = new Headers();
           requestHeaders.set('Content-Type', 'application/json');
           requestHeaders.set('token', sessionStorage.getItem('jwt') as string);
@@ -28,7 +29,6 @@ const submitReview = (
       },
       {
         label: '취소',
-        className: 'overlay-confirmation-cancel',
         onClick: () => {
           return;
         },
@@ -36,7 +36,6 @@ const submitReview = (
     ],
     closeOnEscape: false,
     closeOnClickOutside: false,
-    overlayClassName: 'overlay-confirmation-alert',
   });
 };
 

--- a/client/src/controllers/reviewController.ts
+++ b/client/src/controllers/reviewController.ts
@@ -66,8 +66,14 @@ const fetchContentData = async (
 };
 
 const parseHashtags = (text: string) =>
-  Array.from(text.matchAll(/#[^#\s]*/g)).map((hashtag) =>
-    hashtag[0].replace('#', ''),
-  );
+  Array.from(text.matchAll(/#[^#\s]*/g))
+    .map((hashtag) => hashtag[0].replace('#', ''))
+    .reduce((a, hashtag) => {
+      if (!a.includes(hashtag)) {
+        return [...a, hashtag];
+      } else {
+        return a;
+      }
+    }, <string[]>[]);
 
 export { submitReview, fetchContentData, parseHashtags };

--- a/client/src/controllers/signInController.ts
+++ b/client/src/controllers/signInController.ts
@@ -49,11 +49,6 @@ const isMember = (
   }
 
   if (status == 200 && !userInfo.result.jwtToken) {
-    setAuth({
-      ...auth,
-      oauth_email: userInfo.result.oauthEmail,
-      image: userInfo.result.image,
-    });
     routeHistory('/signup', {
       background: location,
       oauth_email: userInfo.result.oauthEmail,

--- a/client/src/controllers/signInController.ts
+++ b/client/src/controllers/signInController.ts
@@ -63,6 +63,7 @@ const isMember = (
     sessionstorage에 jwt토큰 값을 저장 && recoil update && 메인페이지로 routing
     */
     sessionStorage.setItem('jwt', userInfo.result.jwtToken);
+    sessionStorage.setItem('refreshToken', userInfo.result.refreshToken);
     setAuth({
       ...auth,
       isLoggedin: true,

--- a/client/src/controllers/signUpController.ts
+++ b/client/src/controllers/signUpController.ts
@@ -46,6 +46,7 @@ const isSignUp = (
     routeHistory('/signin', { background: location });
   } else {
     sessionStorage.setItem('jwt', userInfo.result.jwtToken);
+    sessionStorage.setItem('refreshToken', userInfo.result.refreshToken);
     setAuth({
       ...auth,
       isLoggedin: true,

--- a/client/src/controllers/signUpController.ts
+++ b/client/src/controllers/signUpController.ts
@@ -1,7 +1,7 @@
 import { SetterOrUpdater } from 'recoil';
 
 import { IAPIResult } from '@myTypes/Common';
-import { IToken } from '@myTypes/User';
+import { ISignUp } from '@myTypes/User';
 import { IMapInfo } from '@myTypes/Map';
 import { IAuthInfo } from '@myTypes/User';
 
@@ -9,7 +9,7 @@ const signUpAdress = async (
   mapInfo: IMapInfo,
   auth: IAuthInfo,
   location,
-): Promise<[number, IAPIResult<IToken | Record<string, never>>]> => {
+): Promise<[number, IAPIResult<ISignUp | Record<string, never>>]> => {
   const response = await fetch(
     `${process.env.REACT_APP_API_URL}/api/auth/signup`,
     {
@@ -27,7 +27,7 @@ const signUpAdress = async (
     },
   );
 
-  const userInfo: IAPIResult<IToken | Record<string, never>> =
+  const userInfo: IAPIResult<ISignUp | Record<string, never>> =
     await response.json();
 
   return [response.status, userInfo];
@@ -35,7 +35,7 @@ const signUpAdress = async (
 
 const isSignUp = (
   status: number,
-  userInfo: IAPIResult<IToken | Record<string, never>>,
+  userInfo: IAPIResult<ISignUp | Record<string, never>>,
   auth: IAuthInfo,
   setAuth: SetterOrUpdater<IAuthInfo>,
   routeHistory,

--- a/client/src/pages/MainPage.tsx
+++ b/client/src/pages/MainPage.tsx
@@ -1,4 +1,4 @@
-import Map from '@components/Map/index';
+import MapComponent from '@components/Map/index';
 
 import React, { useState, useCallback, Suspense } from 'react';
 import styled from 'styled-components';
@@ -21,37 +21,6 @@ const FlexContainer = styled.div`
   flex: 1 1 0;
 `;
 
-// const TemporaryReviewData: IReviewContent[] = [
-//   {
-//     categories: {
-//       safety: 4,
-//       traffic: 4,
-//       food: 5,
-//       entertainment: 3,
-//     },
-//     text: 'ㄴㅇㅁㄹ머ㅗㅇ피ㅓ멀호매asdfasdfgadfhawesfds;ㅓ두ㅗㅇ러;뮈퍼ㅠㅏㅣ너ㅠㅗㅎ머ㅣㅠ이러ㅓ',
-//     user: 'github:user1',
-//   },
-//   {
-//     categories: {
-//       safety: 4,
-//       traffic: 4,
-//       food: 4,
-//       entertainment: 4,
-//     },
-//     text: '우하하하우하하하우하하하우하하하우하하하우하하하우하하하우하하하',
-//     user: 'github:user2',
-//   },
-// ];
-
-const TemporaryHashTagData: string[] = [
-  '소음이 적은',
-  '경관이 좋은',
-  '문화시설이 가까운',
-  '체육시설이 많은',
-  '역이 가까운',
-];
-
 const DEFAULT_RATE_DATA: IMapInfo = {
   address: '',
   code: '',
@@ -64,6 +33,7 @@ const DEFAULT_RATE_DATA: IMapInfo = {
     food: 0,
     entertainment: 0,
   },
+  hashtags: new Map(),
 };
 
 const MainPage: React.FC = () => {
@@ -93,12 +63,12 @@ const MainPage: React.FC = () => {
   return (
     <MainDiv>
       <FlexContainer>
-        <Map
+        <MapComponent
           openSidebar={openSidebar}
           closeSidebar={closeSidebar}
           updateSidebarRate={updateSidebarRate}
           updateSidebarContents={updateSidebarContents}
-        ></Map>
+        ></MapComponent>
         {sidebar && (
           <Suspense fallback="loading...">
             <SidebarLazy
@@ -106,7 +76,7 @@ const MainPage: React.FC = () => {
               rateData={sidebarRate}
               contentsData={sidebarContents}
               setContentsData={setSidebarContents}
-              hashTagData={TemporaryHashTagData}
+              hashTagData={sidebarRate.hashtags}
               closeSidebar={closeSidebar}
             ></SidebarLazy>
           </Suspense>

--- a/client/src/styledComponents/GlobalStyle.ts
+++ b/client/src/styledComponents/GlobalStyle.ts
@@ -14,6 +14,12 @@ const GlobalStyle = createGlobalStyle`
     font-family: "Noto Sans KR";
   }
 
+  #root {
+    width: 100%;
+    height: 100%;
+    position: fixed;
+  }
+
   button {
     border: none;
   }

--- a/client/src/types/Map.d.ts
+++ b/client/src/types/Map.d.ts
@@ -19,6 +19,7 @@ interface IMapInfo {
   count: number;
   //현재는 리뷰 정보가 없으므로 require를 false로함
   categories: ICategories;
+  hashtags: Map<string, number> | Map;
 }
 
 interface IPolygon extends kakao.maps.Polygon {

--- a/client/src/types/Review.d.ts
+++ b/client/src/types/Review.d.ts
@@ -10,6 +10,7 @@ interface IReviewSubmit {
   text: string;
   oauth_email: string;
   categories: ICategories;
+  hashtags?: string[];
 }
 
 interface IReviewContent {

--- a/client/src/types/User.d.ts
+++ b/client/src/types/User.d.ts
@@ -6,6 +6,7 @@ interface IUser {
 
 interface IUserInfo extends IUser {
   jwtToken: string;
+  refreshToken: string;
   oauthEmail: string;
   address: string;
   image: string;
@@ -17,6 +18,7 @@ interface IAuthInfo extends IUser {
 
 interface IToken {
   jwtToken: string;
+  refreshToken: string;
   address: string;
 }
 

--- a/client/src/types/User.d.ts
+++ b/client/src/types/User.d.ts
@@ -19,7 +19,10 @@ interface IAuthInfo extends IUser {
 interface IToken {
   jwtToken: string;
   refreshToken: string;
+}
+
+interface ISignUp extends IToken {
   address: string;
 }
 
-export { IUserInfo, IAuthInfo, IToken };
+export { IUserInfo, IAuthInfo, IToken, ISignUp };

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -7186,6 +7186,18 @@ jsonfile@^6.0.1:
     array-includes "^3.1.3"
     object.assign "^4.1.2"
 
+jwt-check-expiration@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/jwt-check-expiration/-/jwt-check-expiration-1.0.5.tgz#4161c3090831b5279f8f0d7cb44ecb08ad852991"
+  integrity sha512-Ov2A7f/zwiZ8wvi6KG+Jeb6am1pvwgcms+HytB4GMPzrCf5UfytnlBVRh9a39Hi2v91H3aETtXHZreB8BTdbUQ==
+  dependencies:
+    jwt-decode "^2.2.0"
+
+jwt-decode@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/jwt-decode/-/jwt-decode-2.2.0.tgz#7d86bd56679f58ce6a84704a657dd392bba81a79"
+  integrity sha1-fYa9VmefWM5qhHBKZX3TkruoGnk=
+
 killable@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/killable/-/killable-1.0.1.tgz"

--- a/server/package.json
+++ b/server/package.json
@@ -27,6 +27,7 @@
     "multer": "^1.4.3",
     "pm2": "^5.1.2",
     "proj4": "^2.7.5",
+    "rand-token": "^1.0.1",
     "simplify-js": "^1.2.4",
     "tsconfig-paths": "^3.11.0",
     "uuid": "^8.3.2",

--- a/server/src/api/authController.ts
+++ b/server/src/api/authController.ts
@@ -26,6 +26,7 @@ router.post('/signin', (async (req: AuthRequest, res: Response) => {
     const isMember = await authService.isMember(oauthEmail.oauth_email);
     let userInfo = {
       jwtToken: '',
+      refreshToken: '',
       oauthEmail: '',
       address: '',
       image: '',
@@ -36,6 +37,7 @@ router.post('/signin', (async (req: AuthRequest, res: Response) => {
       userInfo = {
         ...userInfo,
         jwtToken: jwtToken.token,
+        refreshToken: jwtToken.refreshToken,
         oauthEmail: isMember.oauth_email,
         address: isMember.address,
         image: isMember.image as string,
@@ -71,14 +73,16 @@ router.post('/signup', (async (req: Request, res: Response) => {
     await authService.saveUserInfo(newUserInfo);
     const jwtToken = jwt.sign({ oauth_email: oauthEmail });
 
-    res
-      .status(200)
-      .json(
-        makeApiResponse(
-          { jwtToken: jwtToken.token, address: address },
-          '성공적으로 회원가입 되었습니다.',
-        ),
-      );
+    res.status(200).json(
+      makeApiResponse(
+        {
+          jwtToken: jwtToken.token,
+          refreshToken: jwtToken.refreshToken,
+          address: address,
+        },
+        '성공적으로 회원가입 되었습니다.',
+      ),
+    );
   } catch (error) {
     const err = error as Error;
     logger.error(err.message);

--- a/server/src/api/reviewController.ts
+++ b/server/src/api/reviewController.ts
@@ -58,6 +58,10 @@ router.post('/', checkToken, (async (
     const insertData = req.body;
     if (!insertData) throw Error('비정상적인 후기 정보가 입력되었습니다.');
     await reviewService.insertReview(insertData);
+    void reviewService.updateMapInfoHashtag(
+      insertData.address,
+      insertData.hashtags as string[],
+    );
     res
       .status(200)
       .json(makeApiResponse({}, '후기를 정상적으로 저장하였습니다.'));

--- a/server/src/api/reviewController.ts
+++ b/server/src/api/reviewController.ts
@@ -58,7 +58,7 @@ router.post('/', checkToken, (async (
     const insertData = req.body;
     if (!insertData) throw Error('비정상적인 후기 정보가 입력되었습니다.');
     await reviewService.insertReview(insertData);
-    void reviewService.updateMapInfoHashtag(
+    await reviewService.updateMapInfoHashtag(
       insertData.address,
       insertData.hashtags as string[],
     );

--- a/server/src/config/index.ts
+++ b/server/src/config/index.ts
@@ -17,5 +17,9 @@ export default {
   client_id: process.env.CLIENT_ID || '',
   client_secret: process.env.CLIENT_SECRET || '',
   jwt_secret: process.env.JWT_SECRET || '',
+  jwt_refresh_secret: process.env.JWT_REFRESH_SECRET || '',
   jwt_algorithm: process.env.JWT_ALGORITHM || '',
+  jwt_refresh_algorithm: process.env.JWT_REFRESH_ALGORITHM || '',
+  jwt_expire: process.env.JWT_EXPIRE || '',
+  jwt_refresh_expire: process.env.JWT_REFRESH_EXPIRE || '',
 };

--- a/server/src/config/secretKey.ts
+++ b/server/src/config/secretKey.ts
@@ -10,7 +10,16 @@ const jwtConfig: Config = {
   secretKey: config.jwt_secret,
   options: {
     algorithm: config.jwt_algorithm as jwt.Algorithm,
+    expiresIn: config.jwt_expire,
   },
 };
 
-export default jwtConfig;
+const jwtRefreshConfig: Config = {
+  secretKey: config.jwt_refresh_secret,
+  options: {
+    algorithm: config.jwt_refresh_algorithm as jwt.Algorithm,
+    expiresIn: config.jwt_refresh_expire,
+  },
+};
+
+export { jwtConfig, jwtRefreshConfig };

--- a/server/src/middlewares/auth.ts
+++ b/server/src/middlewares/auth.ts
@@ -25,7 +25,9 @@ const checkToken = (
     logger.error('유효기간이 만료되었습니다.');
     return res
       .status(500)
-      .json(makeApiResponse({}, '유효기간 만료되었습니다.'));
+      .json(
+        makeApiResponse({ token: TOKEN_EXPIRED }, '유효기간 만료되었습니다.'),
+      );
   }
   if (user === TOKEN_INVALID) {
     logger.error('유효하지 않은 토큰입니다.');

--- a/server/src/middlewares/auth.ts
+++ b/server/src/middlewares/auth.ts
@@ -1,12 +1,11 @@
-import express, { Response, NextFunction } from 'express';
+import { Response, NextFunction } from 'express';
 import logger from '@loaders/loggerLoader';
 import jwt from '@services/jwtService';
 import { makeApiResponse } from '@utils/index';
 import { AuthMiddleRequest } from '@myTypes/User';
 import { JwtPayload } from 'jsonwebtoken';
-
-const TOKEN_EXPIRED = -3;
-const TOKEN_INVALID = -2;
+import { AuthError } from '@utils/authErrorEnum';
+import { authErrCheck } from '@utils/authError';
 
 const checkToken = (
   req: AuthMiddleRequest,
@@ -21,24 +20,17 @@ const checkToken = (
   }
 
   const user = jwt.verify(token);
-  if (user === TOKEN_EXPIRED) {
+
+  if (user == AuthError.TOKEN_EXPIRED) {
     logger.error('유효기간이 만료되었습니다.');
-    return res
-      .status(500)
-      .json(
-        makeApiResponse({ token: TOKEN_EXPIRED }, '유효기간 만료되었습니다.'),
-      );
-  }
-  if (user === TOKEN_INVALID) {
-    logger.error('유효하지 않은 토큰입니다.');
-    return res
-      .status(500)
-      .json(makeApiResponse({}, '유효하지 않은 토큰입니다.'));
+    return next();
   }
 
-  if ((user as JwtPayload).oauth_email === undefined) {
-    logger.error('잘못된 토큰입니다.');
-    return res.status(500).json(makeApiResponse({}, '잘못된 토큰입니다.'));
+  if (
+    user === AuthError.TOKEN_INVALID ||
+    (user as JwtPayload).oauth_email === undefined
+  ) {
+    return authErrCheck(user, res);
   }
 
   req.id = (user as JwtPayload).oauth_email as string;

--- a/server/src/models/MapInfo.ts
+++ b/server/src/models/MapInfo.ts
@@ -23,9 +23,9 @@ interface MapInfo {
   center: CoordType;
   count: number;
   //현재는 리뷰 정보가 없으므로 require를 false로함
-  categories?: Categories;
+  categories: Categories;
   // eslint-disable-next-line @typescript-eslint/ban-types
-  hashtags?: Map<string, number>;
+  hashtags: Map<string, number>;
 }
 
 const mapInfoSchema = new Schema<MapInfo>({
@@ -35,8 +35,8 @@ const mapInfoSchema = new Schema<MapInfo>({
   center: { type: [Number, Number], required: true },
   count: { type: Number, required: true, default: 0 },
   //현재는 리뷰 정보가 없으므로 require를 false로함
-  categories: { type: rateSchema, required: false },
-  hashtags: { type: Map, required: false },
+  categories: { type: rateSchema, required: true },
+  hashtags: { type: 'Map', required: true },
 });
 
 const MapInfoModel = model<MapInfo>('MapInfo', mapInfoSchema);

--- a/server/src/models/MapInfo.ts
+++ b/server/src/models/MapInfo.ts
@@ -24,6 +24,8 @@ interface MapInfo {
   count: number;
   //현재는 리뷰 정보가 없으므로 require를 false로함
   categories?: Categories;
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  hashtags?: Map<string, number>;
 }
 
 const mapInfoSchema = new Schema<MapInfo>({
@@ -34,6 +36,7 @@ const mapInfoSchema = new Schema<MapInfo>({
   count: { type: Number, required: true, default: 0 },
   //현재는 리뷰 정보가 없으므로 require를 false로함
   categories: { type: rateSchema, required: false },
+  hashtags: { type: Map, required: false },
 });
 
 const MapInfoModel = model<MapInfo>('MapInfo', mapInfoSchema);

--- a/server/src/services/jwtService.ts
+++ b/server/src/services/jwtService.ts
@@ -1,5 +1,6 @@
 import jwt from 'jsonwebtoken';
 import jwtConfig from '@config/secretKey';
+import randToken from 'rand-token';
 
 const TOKEN_EXPIRED = -3;
 const TOKEN_INVALID = -2;
@@ -9,8 +10,9 @@ export default {
     const payload = {
       oauth_email: user.oauth_email,
     };
-    const token: { token: string } = {
+    const token: { token: string; refreshToken: string } = {
       token: jwt.sign(payload, jwtConfig.secretKey, jwtConfig.options),
+      refreshToken: randToken.uid(16),
     };
     return token;
   },

--- a/server/src/services/jwtService.ts
+++ b/server/src/services/jwtService.ts
@@ -1,8 +1,6 @@
 import jwt from 'jsonwebtoken';
 import { jwtConfig, jwtRefreshConfig } from '@config/secretKey';
-
-const TOKEN_EXPIRED = -3;
-const TOKEN_INVALID = -2;
+import { AuthError } from '@utils/authErrorEnum';
 
 export default {
   sign: (user: { oauth_email: string }) => {
@@ -30,11 +28,11 @@ export default {
     } catch (err) {
       const errMsg = (err as Error).message;
       if (errMsg === 'jwt expired') {
-        return TOKEN_EXPIRED;
+        return AuthError.TOKEN_EXPIRED;
       } else if (errMsg === 'invalid token') {
-        return TOKEN_INVALID;
+        return AuthError.TOKEN_INVALID;
       } else {
-        return TOKEN_INVALID;
+        return AuthError.TOKEN_INVALID;
       }
     }
     return decoded;

--- a/server/src/services/jwtService.ts
+++ b/server/src/services/jwtService.ts
@@ -1,6 +1,5 @@
 import jwt from 'jsonwebtoken';
-import jwtConfig from '@config/secretKey';
-import randToken from 'rand-token';
+import { jwtConfig, jwtRefreshConfig } from '@config/secretKey';
 
 const TOKEN_EXPIRED = -3;
 const TOKEN_INVALID = -2;
@@ -12,14 +11,22 @@ export default {
     };
     const token: { token: string; refreshToken: string } = {
       token: jwt.sign(payload, jwtConfig.secretKey, jwtConfig.options),
-      refreshToken: randToken.uid(16),
+      refreshToken: jwt.sign(
+        payload,
+        jwtRefreshConfig.secretKey,
+        jwtRefreshConfig.options,
+      ),
     };
     return token;
   },
-  verify: (token: string) => {
+  verify: (token: string, kind = 'jwt') => {
     let decoded: string | jwt.JwtPayload;
     try {
-      decoded = jwt.verify(token, jwtConfig.secretKey);
+      if (kind === 'jwt') {
+        decoded = jwt.verify(token, jwtConfig.secretKey);
+      } else {
+        decoded = jwt.verify(token, jwtRefreshConfig.secretKey);
+      }
     } catch (err) {
       const errMsg = (err as Error).message;
       if (errMsg === 'jwt expired') {

--- a/server/src/services/mapService.ts
+++ b/server/src/services/mapService.ts
@@ -66,6 +66,7 @@ const queryRates = async (
     'categories.traffic': 1,
     'categories.food': 1,
     'categories.entertainment': 1,
+    hashtags: true,
   };
 
   switch (true) {
@@ -96,6 +97,13 @@ const queryRates = async (
       );
       break;
   }
+
+  result.forEach((r) => {
+    if (!r.hashtags) {
+      r.hashtags = new Map();
+    }
+  });
+
   return result;
 };
 

--- a/server/src/services/reviewService.ts
+++ b/server/src/services/reviewService.ts
@@ -51,9 +51,6 @@ const insertReview = async (data: ReviewInsertData) => {
   await mapService.updateRates(mapData.code, data);
 };
 
-const parseHashtags = (text: string) =>
-  Array.from(text.matchAll(/#[^#\s]*/g)).map((hashtag) => hashtag[0]);
-
 const getCodeByAddress = async (address: string) => {
   const foundDocument = await MapInfoModel.findOne({ address });
   return foundDocument?.code;
@@ -100,6 +97,5 @@ export default {
   initializeReviewModel,
   queryReviews,
   insertReview,
-  parseHashtags,
   updateMapInfoHashtag,
 };

--- a/server/src/services/reviewService.ts
+++ b/server/src/services/reviewService.ts
@@ -1,7 +1,8 @@
-import { MapInfo } from '@models/MapInfo';
+import { MapInfo, MapInfoModel } from '@models/MapInfo';
 import { Review, ReviewModel } from '@models/Review';
 import { ReviewFindData, ReviewInsertData } from '@myTypes/Review';
 import { mapService } from '@services/index';
+import logger from '@loaders/loggerLoader';
 
 const dropModel = async () => {
   await ReviewModel.collection.drop();
@@ -53,10 +54,54 @@ const insertReview = async (data: ReviewInsertData) => {
 const parseHashtags = (text: string) =>
   Array.from(text.matchAll(/#[^#\s]*/g)).map((hashtag) => hashtag[0]);
 
+const getCodeByAddress = async (address: string) => {
+  const foundDocument = await MapInfoModel.findOne({ address });
+  return foundDocument?.code;
+};
+
+const findAndModifyHashtag = async (
+  condition: { codeLength: number; code: string },
+  hashtags: string[],
+) => {
+  const foundDocument = await MapInfoModel.findOne(condition);
+  if (!foundDocument) {
+    throw new Error('해시태그를 업데이트하는데 condition이 이상합니다!');
+  } else {
+    const prevHashtags = foundDocument.hashtags ?? new Map<string, number>();
+    hashtags.forEach((hashtag) => {
+      const prevCount = prevHashtags.get(hashtag) ?? 0;
+      prevHashtags.set(hashtag, prevCount + 1);
+    });
+
+    void MapInfoModel.updateOne(condition, { hashtags: prevHashtags }).then(
+      () => logger.info('해시태그를 업데이트했어요!'),
+    );
+  }
+};
+
+const updateMapInfoHashtag = async (address: string, hashtags: string[]) => {
+  const code = await getCodeByAddress(address);
+  if (!code) {
+    throw new Error('해시태그를 업데이트하는데 address가 이상합니다!');
+  } else {
+    const conditions = [
+      { codeLength: 2, code: code.slice(0, 2) },
+      { codeLength: 5, code: code.slice(0, 5) },
+      { codeLength: 7, code: code },
+    ];
+    conditions.forEach((condition) => {
+      if (condition.codeLength >= code.length) {
+        void findAndModifyHashtag(condition, hashtags);
+      }
+    });
+  }
+};
+
 export default {
   dropModel,
   initializeReviewModel,
   queryReviews,
   insertReview,
   parseHashtags,
+  updateMapInfoHashtag,
 };

--- a/server/src/services/reviewService.ts
+++ b/server/src/services/reviewService.ts
@@ -50,4 +50,13 @@ const insertReview = async (data: ReviewInsertData) => {
   await mapService.updateRates(mapData.code, data);
 };
 
-export default { dropModel, initializeReviewModel, queryReviews, insertReview };
+const parseHashtags = (text: string) =>
+  Array.from(text.matchAll(/#[^#\s]*/g)).map((hashtag) => hashtag[0]);
+
+export default {
+  dropModel,
+  initializeReviewModel,
+  queryReviews,
+  insertReview,
+  parseHashtags,
+};

--- a/server/src/services/reviewService.ts
+++ b/server/src/services/reviewService.ts
@@ -90,9 +90,7 @@ const updateMapInfoHashtag = async (address: string, hashtags: string[]) => {
       { codeLength: 7, code: code },
     ];
     conditions.forEach((condition) => {
-      if (condition.codeLength >= code.length) {
-        void findAndModifyHashtag(condition, hashtags);
-      }
+      void findAndModifyHashtag(condition, hashtags);
     });
   }
 };

--- a/server/src/services/updateMapService.ts
+++ b/server/src/services/updateMapService.ts
@@ -101,6 +101,7 @@ const recursiveGetCoords = async (code: string, accessToken: string) => {
         food: 0,
         entertainment: 0,
       },
+      hashtags: new Map(),
     };
 
     void MapModel.create(regionData).then(() => {

--- a/server/src/types/Review.d.ts
+++ b/server/src/types/Review.d.ts
@@ -11,6 +11,7 @@ export interface ReviewInsertData {
   text: string;
   user: string;
   categories: CategoryRateType;
+  hashtags?: string[];
 }
 
 export interface ReviewFindData {

--- a/server/src/utils/authError.ts
+++ b/server/src/utils/authError.ts
@@ -1,0 +1,21 @@
+import express, { Response, NextFunction } from 'express';
+import { JwtPayload } from 'jsonwebtoken';
+import logger from '@loaders/loggerLoader';
+import { makeApiResponse } from '@utils/index';
+import { AuthError } from '@utils/authErrorEnum';
+
+const authErrCheck = (user: string | -3 | -2 | JwtPayload, res: Response) => {
+  if (user === AuthError.TOKEN_INVALID) {
+    logger.error('유효하지 않은 토큰입니다.');
+    return res
+      .status(500)
+      .json(makeApiResponse({}, '유효하지 않은 토큰입니다.'));
+  }
+
+  if ((user as JwtPayload).oauth_email === undefined) {
+    logger.error('잘못된 토큰입니다.');
+    return res.status(500).json(makeApiResponse({}, '잘못된 토큰입니다.'));
+  }
+};
+
+export { authErrCheck };

--- a/server/src/utils/authErrorEnum.ts
+++ b/server/src/utils/authErrorEnum.ts
@@ -1,0 +1,6 @@
+enum AuthError {
+  TOKEN_EXPIRED = -3,
+  TOKEN_INVALID = -2,
+}
+
+export { AuthError };

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -3304,6 +3304,11 @@ queue-microtask@^1.2.2:
   resolved "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
+rand-token@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/rand-token/-/rand-token-1.0.1.tgz#a47fdfd94894cc349d74234403c4b24624733c58"
+  integrity sha512-Zri5SfJmEzBJ3IexFdigvPSCamslJ7UjLkUn0tlgH7COJvaUr5V7FyUYgKifEMTw7gFO8ZLcWjcU+kq8akipzg==
+
 range-parser@~1.2.1:
   version "1.2.1"
   resolved "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz"


### PR DESCRIPTION
### 🔨 작업 내용 설명
해시태그 기능 추가와 자잘한 작업들

### 📑 구현한 내용
- 리뷰를 등록할 때 #으로 시작하는 단어는 해시태그로 인식하여 모달에 표시해줌
- 리뷰를 등록하면 해당 해시태그들을 연관된 동네에 업데이트
  - MapInfo에 해시태그들의 출현수를 Map(딕셔너리)형태로 가지고 있음
  - 현재는 모두 클라이언트에게 보내주고 클라이언트가 그중에서 제일 많이 등장한 5개를 추려내는 식....
- 스타일 수정
  - 헤더 버튼 호버 색상 변경
  - 사이드바 스타일 패딩, 여유, 갭 수정
  - confirm alert 버튼 색상 수정, 뒷 화면 깨지는거 수정
- 사이드바 글 쓴 시간 적절한 단위의 시간으로 보여지도록 수정

### 🚧 주의 사항
- 해시태그를 모두 보내주는것 나중에(나중이 있나...) 좀더 클라이언트에게 부담을 줄일 필요가 있다.
- 해시태그를 지금 캐싱하면서, 해시태그가 업데이트되었을 때 다시 캐싱된 데이터를 refresh해주는 로직이 필요하다.
- {}와 Map사이에서 stringify, react, typescript가 만나서 아주 나를 힘들게 했다...

### 스크린 샷
![hashtag](https://user-images.githubusercontent.com/54357553/142773193-e1dd93b2-cacd-414c-9235-a77b790597ba.gif)
![Screen Shot 2021-11-22 at 2 44 26](https://user-images.githubusercontent.com/54357553/142773205-e3868a74-c9d3-423b-85ab-2d798f7e003a.png)

closes #120 