### PR TITLE
Fix/hashtag 해시태그 예외 처리, 수정

### DIFF
--- a/client/src/components/Sidebar/index.tsx
+++ b/client/src/components/Sidebar/index.tsx
@@ -36,12 +36,6 @@ const Sidebar: React.FC<IProps> = (props: IProps) => {
 
   const total = calcTotal(props.rateData.categories) / props.rateData.count;
 
-  const filterTop5Hashtags = (hashtags: Map<string, number>) =>
-    Array.from(hashtags.entries())
-      .sort((a, b) => a[1] - b[1])
-      .map((hashtag) => hashtag[0])
-      .slice(0, 5);
-
   return (
     <Layout className={`${props.sidebar ? 'open' : ''}`}>
       <TitleDiv>
@@ -58,11 +52,7 @@ const Sidebar: React.FC<IProps> = (props: IProps) => {
       </RateDiv>
       <HashTagDiv>
         {Object.keys(props.hashTagData).length ? (
-          <HashTagList
-            hashTags={filterTop5Hashtags(
-              new Map(Object.entries(props.hashTagData)),
-            )}
-          />
+          <HashTagList hashTags={Object.keys(props.hashTagData)} />
         ) : (
           <HashTagNo>아직 해시태그가 없어요...</HashTagNo>
         )}

--- a/client/src/controllers/reviewController.ts
+++ b/client/src/controllers/reviewController.ts
@@ -67,6 +67,7 @@ const fetchContentData = async (
 const parseHashtags = (text: string) =>
   Array.from(text.matchAll(/#[^#\s]*/g))
     .map((hashtag) => hashtag[0].replace('#', ''))
+    .filter((hashtag) => hashtag.length)
     .reduce((a, hashtag) => {
       if (!a.includes(hashtag)) {
         return [...a, hashtag];

--- a/server/src/services/mapService.ts
+++ b/server/src/services/mapService.ts
@@ -1,5 +1,5 @@
 import { ClientSession } from 'mongoose';
-import { Map, MapModel } from '@models/Map';
+import { Map as IMap, MapModel } from '@models/Map';
 import { MapInfo, MapInfoModel } from '@models/MapInfo';
 import { ReviewInsertData } from '@myTypes/Review';
 
@@ -8,8 +8,8 @@ const queryPolygon = async (
   big: string,
   medium: string,
   small: string,
-): Promise<Map[]> => {
-  let result: Map[] = [];
+): Promise<IMap[]> => {
+  let result: IMap[] = [];
 
   switch (true) {
     case scale < 9:
@@ -48,6 +48,11 @@ const queryCenter = async (
     ? { address: { $regex: RegExp(keyword, 'g') }, codeLength: 7 }
     : { address: { $regex: RegExp(keyword, 'g') } };
   return await MapInfoModel.find(query).session(session);
+};
+
+const findTop5Hashtags = (hashtags: Map<string, number>) => {
+  const candidates = hashtags.entries();
+  return new Map([...candidates].sort((a, b) => b[1] - a[1]).slice(0, 5));
 };
 
 const queryRates = async (
@@ -103,6 +108,8 @@ const queryRates = async (
   result.forEach((r) => {
     if (!r.hashtags) {
       r.hashtags = new Map();
+    } else {
+      r.hashtags = findTop5Hashtags(r.hashtags);
     }
   });
 

--- a/server/src/services/reviewService.ts
+++ b/server/src/services/reviewService.ts
@@ -105,10 +105,12 @@ const findAndModifyHashtag = async (
     throw new Error('해시태그를 업데이트하는데 condition이 이상합니다!');
   } else {
     const prevHashtags = foundDocument.hashtags ?? new Map<string, number>();
-    hashtags.forEach((hashtag) => {
-      const prevCount = prevHashtags.get(hashtag) ?? 0;
-      prevHashtags.set(hashtag, prevCount + 1);
-    });
+    hashtags
+      .filter((hashtag) => hashtag.length)
+      .forEach((hashtag) => {
+        const prevCount = prevHashtags.get(hashtag) ?? 0;
+        prevHashtags.set(hashtag, prevCount + 1);
+      });
 
     await MapInfoModel.updateOne(
       condition,


### PR DESCRIPTION
### 🔨 작업 내용 설명
해시태그 기능 에외 처리, 수정

### 📑 구현한 내용
- 해시태그 상위 5개 태그 서버에서 찾아서 클라이언트로 보내주도록 수정
- 해시태그 빈 문자열 예외처리
  - Client에서 한번 걸러줌 -> 빈 문자열은 해시태그로 인식하지 않음
  - Server에서도 한번 걸러줌

 closes #142 
