### PR TITLE
Feat/polygon color 폴리곤 색상 겹치지 않도록 수정

### DIFF
--- a/client/src/controllers/mapController.ts
+++ b/client/src/controllers/mapController.ts
@@ -115,14 +115,11 @@ const isLike = (color1: string, color2: string) => {
 const createPolygons = (regions) => {
   const polygons = Array<IPolygon>();
   const colorHash = new ColorHash();
-  const colors = [''];
-  regions.forEach((region) => {
-    let color: string = colorHash.hex(region.address);
-    let i = 0;
-    while (colors.filter((c) => isLike(c, color)).length) {
-      color = colorHash.hex(`${region.address}${i++}`);
-    }
-    colors.push(color);
+  const keyString = '!@#$';
+  let resultString = '';
+  regions.forEach((region, i) => {
+    const color: string = colorHash.hex(resultString);
+    resultString += keyString;
     if (region.type === 'Polygon') {
       polygons.push(makeSinglePolygon(region.path, region.address, color));
     } else {

--- a/client/src/controllers/mapController.ts
+++ b/client/src/controllers/mapController.ts
@@ -104,19 +104,29 @@ const requestCoord = async (
     });
 };
 
+const isLike = (color1: string, color2: string) => {
+  color1 = color1.replace('#', '');
+  color2 = color2.replace('#', '');
+  return (
+    Array.from(color1).filter((_, i) => color1[i] === color2[i]).length >= 3
+  );
+};
+
 const createPolygons = (regions) => {
   const polygons = Array<IPolygon>();
   const colorHash = new ColorHash();
+  const colors = [''];
   regions.forEach((region) => {
-    const colorString = colorHash.hex(region.address);
+    let color: string = colorHash.hex(region.address);
+    let i = 0;
+    while (colors.filter((c) => isLike(c, color)).length) {
+      color = colorHash.hex(`${region.address}${i++}`);
+    }
+    colors.push(color);
     if (region.type === 'Polygon') {
-      polygons.push(
-        makeSinglePolygon(region.path, region.address, colorString),
-      );
+      polygons.push(makeSinglePolygon(region.path, region.address, color));
     } else {
-      polygons.push(
-        ...makeMultiPolygon(region.path, region.address, colorString),
-      );
+      polygons.push(...makeMultiPolygon(region.path, region.address, color));
     }
   });
   return polygons;


### PR DESCRIPTION
### 🔨 작업 내용 설명
- 폴리곤 인접 색상과 겹치지 않도록 수정

### 📑 구현한 내용
- 폴리곤을 겹치지 않도록 함
  1. 생성된 폴리곤을 돌아보면서 비슷한 값이 있다면 다시 계산
  2. colorhash의 생성 인자로 정해진 문자열(특정한 문자열이 반복적으로 붙음) 

### 🚧 주의 사항
- 1번과 2번 둘중에 어떤걸 해야할지 같이 이야기 나눠보고 싶어요...
- 색깔이 절대 같아지지 않도록 하는 알고리즘을 구현하려면 그래프로 구성해야 되는데, 저희 데이터는 그래프가 아니라서...

closes #147 
