### PR TITLE
[Feat] SWR 캐시에 Eviction Policy 적용

### DIFF
--- a/client/src/hooks/cacheProvider.ts
+++ b/client/src/hooks/cacheProvider.ts
@@ -1,0 +1,74 @@
+import { Cache } from 'swr';
+
+const symCompareKey = Symbol('CompareKey');
+
+interface ICacheItem {
+  value: unknown;
+  [symCompareKey]: number;
+}
+
+const cacheProvider = (
+  maxPolygons: number,
+  policy: 'LFU' | 'LRU' = 'LFU',
+): Cache => {
+  const polygonCache = new Map<string, ICacheItem>();
+  const generalCache = new Map();
+
+  const get = (key: string) => {
+    if (!key.includes('polygon')) {
+      return generalCache.get(key);
+    } else {
+      if (polygonCache.has(key)) {
+        const cacheItem = polygonCache.get(key) as ICacheItem;
+
+        if (policy === 'LFU') {
+          cacheItem[symCompareKey]++;
+        } else {
+          cacheItem[symCompareKey] = Date.now();
+        }
+      }
+      return polygonCache.get(key)?.value;
+    }
+  };
+
+  const set = (key: string, value: unknown) => {
+    if (!key.includes('polygon')) {
+      generalCache.set(key, value);
+      return;
+    }
+
+    if (polygonCache.size >= maxPolygons) {
+      const evictedKey = Array.from(polygonCache.entries()).sort(
+        ([, a], [, b]) => a[symCompareKey] - b[symCompareKey],
+      )[0][0];
+      polygonCache.delete(evictedKey);
+    }
+
+    let compareKey: number;
+    if (policy === 'LFU') {
+      compareKey = 1;
+    } else {
+      compareKey = Date.now();
+    }
+    polygonCache.set(key, {
+      value: value,
+      [symCompareKey]: compareKey,
+    });
+  };
+
+  const cacheDelete = (key: string) => {
+    if (!key.includes('polygon')) {
+      generalCache.delete(key);
+    } else {
+      polygonCache.delete(key);
+    }
+  };
+
+  return {
+    get,
+    set,
+    delete: cacheDelete,
+  };
+};
+
+export default cacheProvider;

--- a/client/src/hooks/cacheProvider.ts
+++ b/client/src/hooks/cacheProvider.ts
@@ -7,6 +7,11 @@ interface ICacheItem {
   [symCompareKey]: number;
 }
 
+const isPolygonKey = (key: string) => {
+  if (key.includes('$req') || key.includes('$err')) return false;
+  return key.includes('polygon');
+};
+
 const cacheProvider = (
   maxPolygons: number,
   policy: 'LFU' | 'LRU' = 'LFU',
@@ -15,7 +20,7 @@ const cacheProvider = (
   const generalCache = new Map();
 
   const get = (key: string) => {
-    if (!key.includes('polygon')) {
+    if (!isPolygonKey(key)) {
       return generalCache.get(key);
     } else {
       if (polygonCache.has(key)) {
@@ -32,7 +37,7 @@ const cacheProvider = (
   };
 
   const set = (key: string, value: unknown) => {
-    if (!key.includes('polygon')) {
+    if (!isPolygonKey(key)) {
       generalCache.set(key, value);
       return;
     }
@@ -57,7 +62,7 @@ const cacheProvider = (
   };
 
   const cacheDelete = (key: string) => {
-    if (!key.includes('polygon')) {
+    if (!isPolygonKey(key)) {
       generalCache.delete(key);
     } else {
       polygonCache.delete(key);

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -2,11 +2,17 @@ import App from './App';
 import { GlobalStore } from '@stores/index';
 import GlobalStyle from '@styledComponents/GlobalStyle';
 import myTheme from '@styledComponents/theme';
+import cacheProvider from '@hooks/cacheProvider';
 
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { BrowserRouter } from 'react-router-dom';
 import { ThemeProvider } from 'styled-components';
+import { SWRConfig } from 'swr';
+
+const MAX_POLYGONS = 10;
+const EVICTION_POLICY: 'LFU' | 'LRU' = 'LFU';
+const swrCacheProvider = () => cacheProvider(MAX_POLYGONS, EVICTION_POLICY);
 
 ReactDOM.render(
   <React.StrictMode>
@@ -14,7 +20,9 @@ ReactDOM.render(
     <ThemeProvider theme={myTheme}>
       <GlobalStore>
         <BrowserRouter>
-          <App />
+          <SWRConfig value={{ provider: swrCacheProvider }}>
+            <App />
+          </SWRConfig>
         </BrowserRouter>
       </GlobalStore>
     </ThemeProvider>


### PR DESCRIPTION
### 🔨 작업 내용 설명
- SWR은 기본적으로 용량이 무제한인 `Map` 객체를 캐싱에 사용하지만, 커스텀 캐시를 사용하도록 하는 API를 제공함
- 폴리곤을 그릴 때 사용하는 지역별 경계좌표는 용량이 크기 때문에 Eviction Policy가 필요하다는 의견을 반영
- `fetch`하려는 데이터가 "폴리곤(경계좌표)"일 경우에만 Eviction Policy를 적용하는 캐시를 구현

### 📑 구현한 내용
- `src/hooks/cacheProvider.ts` SWR 커스텀 캐시를 구현. 
  - Eviction Policy를 선택 가능(LFU, LRU)
  - 경계좌표 데이터인 경우에만 정책을 적용
- `src/index.tsx` 캐시 프로바이더를 `App` 컴포넌트에 제공

### 🚧 주의 사항
- 처음에는 캐시에서 키가 `polygon`을 포함하는 경우에만(e.g. `http://.../api/map/polygon?...`) 캐시 정책을 적용하려고 하였는데, SWR은 캐시에 이와는 별도로 `$req$http://.../api/map/polygon?...`과 `$err$http://.../api/map/polygon?...` 등 내부적으로 사용하는 값들을 따로 저장하고 있습니다. 
- 실제로 경계좌표를 포함하는 데이터에만 캐시 정책을 적용하기 위해 이를 피하기 위한 로직을 추가하였으나(`isPolygonKey()`) SWR 내부 구현방식에 의존하는 듯하여 베스트라고 보이지는 않습니다. (실제로 캐시를 로그로 찍어보기 전에는 절대로 알 수 없는 내용입니다)

### 스크린 샷
![Animation3](https://user-images.githubusercontent.com/24454874/143075931-7a9d2d3a-4f26-4f06-bdd1-ed3ef32b27a6.gif)
`polygonCache` 객체를 로그로 찍은 화면입니다. 사이즈가 10개 넘어 커지지 않습니다. 

close #153
