### PR TITLE
[Feat] 로그인 유지와 상태값 유지

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -2,7 +2,6 @@
 import {
   NotFoundPage,
   MainPage,
-  ReviewPage,
   ReviewSubmitPage,
   LoadPage,
   RankingPage,
@@ -17,19 +16,11 @@ import GlobalStyle from '@styledComponents/GlobalStyle';
 import myTheme from '@styledComponents/theme';
 import Header from '@components/Header/index';
 import Snackbar from '@components/Snackbar';
-import { isJwtExpired } from 'jwt-check-expiration';
+import PrivateRoute from '@routes/PrivateRoute';
 
-import React, { useState, useCallback, useEffect } from 'react';
-import {
-  Switch,
-  Route,
-  Redirect,
-  useLocation,
-  RouterProps,
-} from 'react-router-dom';
+import React from 'react';
+import { Switch, Route, Redirect } from 'react-router-dom';
 import styled, { ThemeProvider } from 'styled-components';
-import { useRecoilState } from 'recoil';
-import { authState } from '@stores/atoms';
 
 const ContentWrapper = styled.div`
   width: 100%;
@@ -38,42 +29,6 @@ const ContentWrapper = styled.div`
   flex-direction: column;
   align-items: center;
 `;
-
-const PrivateRoute: React.FC<RouterProps> = ({
-  component: Component,
-  ...rest
-}) => {
-  const [auth, setAuth] = useRecoilState(authState);
-  const location = useLocation();
-
-  const checkAll = (props) => {
-    try {
-      const token = sessionStorage.getItem('jwt');
-
-      if (!token) {
-        //로그인을 안 한 상태
-        return <Redirect to={{ pathname: '/map/signin' }} />;
-      }
-      if (!auth.isLoggedin) {
-        //로그인은 했지만 새로고침
-        return <Redirect to={{ pathname: '/loading', state: location }} />;
-      }
-
-      if (isJwtExpired(token)) {
-        //로그인한 상태인데 token이 만료
-        return <Redirect to={{ pathname: '/loading', state: location }} />;
-      } else {
-        //로그인한 상태이며 token이 유효한 상태
-        return <Component {...props} />;
-      }
-    } catch (error) {
-      alert(error);
-      return <Redirect to={{ pathname: '/map/signin' }} />;
-    }
-  };
-
-  return <Route {...rest} render={checkAll} />;
-};
 
 const App: React.FC = () => {
   return (

--- a/client/src/components/Loading/index.style.tsx
+++ b/client/src/components/Loading/index.style.tsx
@@ -1,6 +1,15 @@
 // https://wsss.tistory.com/1214 참고
 import styled, { keyframes } from 'styled-components';
 
+export const Body = styled.div`
+  width: 100%;
+  height: 100vh;
+  display: flex;
+  justify-content: center;
+  background-color: ${(props) => props.theme.colors.green};
+  overflow: hidden;
+`;
+
 const ball = keyframes`
     0%, 25%{ top: -50px; }
     35%{ top: calc(60% - 50px ); }

--- a/client/src/components/Loading/index.tsx
+++ b/client/src/components/Loading/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {
+  Body,
   BallWrapper,
   Balls,
   Balls_1,
@@ -15,20 +16,24 @@ import {
 
 const LoadAnimation: React.FC = () => {
   return (
-    <BallWrapper>
-      <Balls>
-        <Balls_1 />
-        <Balls_2 />
-        <Balls_3 />
-        <Balls_4 />
-      </Balls>
-      <Balls>
-        <Balls_5 />
-        <Balls_6 />
-        <Balls_7 />
-        <Balls_8 />
-      </Balls>
-    </BallWrapper>
+    <>
+      <Body>
+        <BallWrapper>
+          <Balls>
+            <Balls_1 />
+            <Balls_2 />
+            <Balls_3 />
+            <Balls_4 />
+          </Balls>
+          <Balls>
+            <Balls_5 />
+            <Balls_6 />
+            <Balls_7 />
+            <Balls_8 />
+          </Balls>
+        </BallWrapper>
+      </Body>
+    </>
   );
 };
 

--- a/client/src/controllers/authController.ts
+++ b/client/src/controllers/authController.ts
@@ -1,19 +1,15 @@
-import { isJwtExpired } from 'jwt-check-expiration';
-
 import { IAPIResult } from '@myTypes/Common';
 import { IToken } from '@myTypes/User';
 
 /*
-2021-11-20
+2021-11-24
 문혜현
+로그인은 했지만 새로고침 token && !auth.isLoggedin
+로그인한 상태인데 token이 만료 token && auth.isLoggedin && isJwtExpired(token)
+위의 경우를 가정함
 token이 잘못되었거나 access와 refresh token이 만료된 경우로 모든 경우에 대해서 sessionStorage를 비우고 로그인 페이지로 이동시킴
 */
-const checkExpired = async (routeHistory) => {
-  const token = sessionStorage.getItem('jwt');
-
-  if (!isJwtExpired(token)) {
-    return;
-  }
+const newIssuedToken = async () => {
   const requestHeaders: HeadersInit = new Headers();
   requestHeaders.set('token', sessionStorage.getItem('jwt') as string);
   requestHeaders.set(
@@ -40,10 +36,11 @@ const checkExpired = async (routeHistory) => {
     token이 잘못되었거나 access와 refresh token이 만료된 경우로 모든 경우에 대해서 sessionStorage를 비우고 로그인 페이지로 이동시킴
     */
     sessionStorage.clear();
-    routeHistory('/map/signin');
+    return false;
   } else {
     sessionStorage.setItem('jwt', newToken.result.jwtToken);
+    return true;
   }
 };
 
-export { checkExpired };
+export { newIssuedToken };

--- a/client/src/controllers/loadController.ts
+++ b/client/src/controllers/loadController.ts
@@ -1,0 +1,60 @@
+import { IUser } from '@myTypes/User';
+import { IAPIResult } from '@myTypes/Common';
+import { newIssuedToken } from '@controllers/authController';
+
+const refreshTokenUser = async (auth, setAuth, routeHistory, location) => {
+  /*
+    2021-11-24
+    문혜현
+    access token을 재발급
+    */
+  const continueMember = await newIssuedToken();
+
+  if (!continueMember) {
+    setAuth({
+      ...auth,
+      isLoggedin: false,
+      oauth_email: '',
+      address: '',
+      image: '',
+    });
+    routeHistory('/map/signin');
+  }
+
+  if (auth.isLoggedin) {
+    /*
+    2021-11-24
+    문혜현
+    access token만 재발급하는 경우
+    */
+    routeHistory(location.state.pathname);
+  } else {
+    /*
+    2021-11-24
+    문혜현
+    user 정보도 재발급하는 경우
+    */
+    const requestHeaders: HeadersInit = new Headers();
+    requestHeaders.set('token', sessionStorage.getItem('jwt') as string);
+    const userInfoResponse = await fetch(
+      `${process.env.REACT_APP_API_URL as string}/api/auth/info`,
+      {
+        method: 'GET',
+        headers: requestHeaders,
+      },
+    );
+    const userInfo: IAPIResult<IUser | Record<string, never>> =
+      await userInfoResponse.json();
+    setAuth({
+      ...auth,
+      isLoggedin: true,
+      oauth_email: userInfo.result.oauth_email,
+      address: userInfo.result.address,
+      image: userInfo.result.image,
+    });
+
+    routeHistory(location.state.pathname);
+  }
+};
+
+export { refreshTokenUser };

--- a/client/src/pages/LoadPage.tsx
+++ b/client/src/pages/LoadPage.tsx
@@ -1,0 +1,85 @@
+import React, { useEffect } from 'react';
+import { useRecoilState } from 'recoil';
+import styled from 'styled-components';
+import { useLocation } from 'react-router-dom';
+import { authState } from '@stores/atoms';
+import useHistoryRouter from '@hooks/useHistoryRouter';
+import LoadAnimation from '@components/Loading/index';
+import { IAuthInfo } from '@myTypes/User';
+import { IUser } from '@myTypes/User';
+import { IAPIResult } from '@myTypes/Common';
+import { newIssuedToken } from '@controllers/authController';
+
+const Body = styled.div`
+  width: 100%;
+  height: 100vh;
+  display: flex;
+  justify-content: center;
+  background-color: ${(props) => props.theme.colors.green};
+  overflow: hidden;
+`;
+
+// 로그인은 했지만 새로고침 token && !auth.isLoggedin
+// 로그인한 상태인데 token이 만료 token && auth.isLoggedin && isJwtExpired(token)
+const LoadPage: React.FC = () => {
+  const [auth, setAuth] = useRecoilState<IAuthInfo>(authState);
+  const routeHistory = useHistoryRouter();
+  const location = useLocation();
+
+  useEffect(() => {
+    const check = async () => {
+      // access token을 재발급
+      const continueMember = await newIssuedToken();
+
+      if (!continueMember) {
+        setAuth({
+          ...auth,
+          isLoggedin: false,
+          oauth_email: '',
+          address: '',
+          image: '',
+        });
+        routeHistory('/map/signin');
+      }
+
+      if (auth.isLoggedin) {
+        //access token만 재발급하는 경우
+        routeHistory(location.state.pathname);
+      } else {
+        // user 정보도 재발급하는 경우
+        const requestHeaders: HeadersInit = new Headers();
+        requestHeaders.set('token', sessionStorage.getItem('jwt') as string);
+        const userInfoResponse = await fetch(
+          `${process.env.REACT_APP_API_URL as string}/api/auth/info`,
+          {
+            method: 'GET',
+            headers: requestHeaders,
+          },
+        );
+        const userInfo: IAPIResult<IUser | Record<string, never>> =
+          await userInfoResponse.json();
+        setAuth({
+          ...auth,
+          isLoggedin: true,
+          oauth_email: userInfo.result.oauth_email,
+          address: userInfo.result.address,
+          image: userInfo.result.image,
+        });
+
+        routeHistory(location.state.pathname);
+      }
+    };
+
+    check();
+  }, []);
+
+  return (
+    <>
+      <Body>
+        <LoadAnimation />
+      </Body>
+    </>
+  );
+};
+
+export default LoadPage;

--- a/client/src/pages/LoadPage.tsx
+++ b/client/src/pages/LoadPage.tsx
@@ -8,15 +8,6 @@ import LoadAnimation from '@components/Loading/index';
 import { IAuthInfo } from '@myTypes/User';
 import { refreshTokenUser } from '@controllers/loadController';
 
-const Body = styled.div`
-  width: 100%;
-  height: 100vh;
-  display: flex;
-  justify-content: center;
-  background-color: ${(props) => props.theme.colors.green};
-  overflow: hidden;
-`;
-
 const LoadPage: React.FC = () => {
   const [auth, setAuth] = useRecoilState<IAuthInfo>(authState);
   const routeHistory = useHistoryRouter();
@@ -26,13 +17,7 @@ const LoadPage: React.FC = () => {
     refreshTokenUser(auth, setAuth, routeHistory, location);
   }, []);
 
-  return (
-    <>
-      <Body>
-        <LoadAnimation />
-      </Body>
-    </>
-  );
+  return <LoadAnimation />;
 };
 
 export default LoadPage;

--- a/client/src/pages/LoadPage.tsx
+++ b/client/src/pages/LoadPage.tsx
@@ -6,9 +6,7 @@ import { authState } from '@stores/atoms';
 import useHistoryRouter from '@hooks/useHistoryRouter';
 import LoadAnimation from '@components/Loading/index';
 import { IAuthInfo } from '@myTypes/User';
-import { IUser } from '@myTypes/User';
-import { IAPIResult } from '@myTypes/Common';
-import { newIssuedToken } from '@controllers/authController';
+import { refreshTokenUser } from '@controllers/loadController';
 
 const Body = styled.div`
   width: 100%;
@@ -19,58 +17,13 @@ const Body = styled.div`
   overflow: hidden;
 `;
 
-// 로그인은 했지만 새로고침 token && !auth.isLoggedin
-// 로그인한 상태인데 token이 만료 token && auth.isLoggedin && isJwtExpired(token)
 const LoadPage: React.FC = () => {
   const [auth, setAuth] = useRecoilState<IAuthInfo>(authState);
   const routeHistory = useHistoryRouter();
   const location = useLocation();
 
   useEffect(() => {
-    const check = async () => {
-      // access token을 재발급
-      const continueMember = await newIssuedToken();
-
-      if (!continueMember) {
-        setAuth({
-          ...auth,
-          isLoggedin: false,
-          oauth_email: '',
-          address: '',
-          image: '',
-        });
-        routeHistory('/map/signin');
-      }
-
-      if (auth.isLoggedin) {
-        //access token만 재발급하는 경우
-        routeHistory(location.state.pathname);
-      } else {
-        // user 정보도 재발급하는 경우
-        const requestHeaders: HeadersInit = new Headers();
-        requestHeaders.set('token', sessionStorage.getItem('jwt') as string);
-        const userInfoResponse = await fetch(
-          `${process.env.REACT_APP_API_URL as string}/api/auth/info`,
-          {
-            method: 'GET',
-            headers: requestHeaders,
-          },
-        );
-        const userInfo: IAPIResult<IUser | Record<string, never>> =
-          await userInfoResponse.json();
-        setAuth({
-          ...auth,
-          isLoggedin: true,
-          oauth_email: userInfo.result.oauth_email,
-          address: userInfo.result.address,
-          image: userInfo.result.image,
-        });
-
-        routeHistory(location.state.pathname);
-      }
-    };
-
-    check();
+    refreshTokenUser(auth, setAuth, routeHistory, location);
   }, []);
 
   return (

--- a/client/src/pages/LoadingPage.tsx
+++ b/client/src/pages/LoadingPage.tsx
@@ -8,15 +8,6 @@ import LoadAnimation from '@components/Loading/index';
 import { getToken, isMember } from '@controllers/signInController';
 import { IAuthInfo } from '@myTypes/User';
 
-const Body = styled.div`
-  width: 100%;
-  height: 100vh;
-  display: flex;
-  justify-content: center;
-  background-color: ${(props) => props.theme.colors.green};
-  overflow: hidden;
-`;
-
 const LoadingPage: React.FC = () => {
   const [auth, setAuth] = useRecoilState<IAuthInfo>(authState);
   const routeHistory = useHistoryRouter();
@@ -30,13 +21,7 @@ const LoadingPage: React.FC = () => {
     confirmMember();
   }, []);
 
-  return (
-    <>
-      <Body>
-        <LoadAnimation />
-      </Body>
-    </>
-  );
+  return <LoadAnimation />;
 };
 
 export default LoadingPage;

--- a/client/src/pages/index.ts
+++ b/client/src/pages/index.ts
@@ -8,6 +8,7 @@ import LoadingPage from '@pages/LoadingPage';
 import SignUpPage from '@pages/SignUpPage';
 import ProfilePage from '@pages/ProfilePage';
 import ProfileAddressPage from '@pages/ProfileAddressPage';
+import LoadPage from '@pages/LoadPage';
 
 export {
   NotFoundPage,
@@ -17,6 +18,7 @@ export {
   RankingPage,
   SignInPage,
   LoadingPage,
+  LoadPage,
   SignUpPage,
   ProfilePage,
   ProfileAddressPage,

--- a/client/src/routes/PrivateRoute.tsx
+++ b/client/src/routes/PrivateRoute.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { Route, Redirect, useLocation, RouterProps } from 'react-router-dom';
+import { isJwtExpired } from 'jwt-check-expiration';
+import { useRecoilValue } from 'recoil';
+import { authState } from '@stores/atoms';
+
+const PrivateRoute: React.FC<RouterProps> = ({
+  component: Component,
+  ...rest
+}) => {
+  const auth = useRecoilValue(authState);
+  const location = useLocation();
+
+  const checkAll = (props) => {
+    try {
+      const token = sessionStorage.getItem('jwt');
+
+      if (!token) {
+        //로그인을 안 한 상태
+        return <Redirect to={{ pathname: '/map/signin' }} />;
+      }
+      if (!auth.isLoggedin) {
+        //로그인은 했지만 새로고침
+        return <Redirect to={{ pathname: '/loading', state: location }} />;
+      }
+
+      if (isJwtExpired(token)) {
+        //로그인한 상태인데 token이 만료
+        return <Redirect to={{ pathname: '/loading', state: location }} />;
+      } else {
+        //로그인한 상태이며 token이 유효한 상태
+        return <Component {...props} />;
+      }
+    } catch (error) {
+      alert(error);
+      return <Redirect to={{ pathname: '/map/signin' }} />;
+    }
+  };
+
+  return <Route {...rest} render={checkAll} />;
+};
+
+export default PrivateRoute;

--- a/client/src/types/User.d.ts
+++ b/client/src/types/User.d.ts
@@ -25,4 +25,4 @@ interface ISignUp extends IToken {
   address: string;
 }
 
-export { IUserInfo, IAuthInfo, IToken, ISignUp };
+export { IUser, IUserInfo, IAuthInfo, IToken, ISignUp };

--- a/client/tsconfig.path.json
+++ b/client/tsconfig.path.json
@@ -10,7 +10,8 @@
       "@styledComponents/*": ["styledComponents/*"],
       "@utils/*": ["utils/*"],
       "@myTypes/*": ["types/*"],
-      "@hooks/*": ["hooks/*"]
+      "@hooks/*": ["hooks/*"],
+      "@routes/*": ["routes/*"]
     }
   }
 }

--- a/server/src/services/authService.ts
+++ b/server/src/services/authService.ts
@@ -36,15 +36,15 @@ const getOauthEmail = async (
   return { oauthEmail: data.login, image: data.avatar_url };
 };
 
-const isMember = async (oauth_email: string): Promise<User | null> => {
+const isMember = async (oauth_email: string) => {
   return await UserModel.findOne().where('oauth_email').equals(oauth_email);
 };
 
-const findRegionInfo = async (address: string): Promise<MapInfo | null> => {
+const findRegionInfo = async (address: string) => {
   return await MapInfoModel.findOne().where('address').equals(address);
 };
 
-const saveUserInfo = async (userInfo: User): Promise<User> => {
+const saveUserInfo = async (userInfo: User) => {
   const newUser = new UserModel(userInfo);
   return await newUser.save().catch((err: Error) => {
     err.message = '이미 회원가입하셨습니다.';


### PR DESCRIPTION
### 🔨 작업 내용 설명
로그인 유지와 상태값 유지

### 📑 구현한 내용

- [x] 로그인과 새로고침을 고려한 경우의 수에 맞게 routing 정하기
- [x] loadPage를 만들어 비동기가 처리될 동안 보이기
- [x] 시간이 만료되도 token 받아와서 로그인 연장하기
- [x] 새로고침해서 recoil이 날아갔을 때 다시 백엔드에서 값 받아오기 

### 🚧 주의 사항
- location.state를 사용하니 map의 경우 unmounted에 관한 error가 나왔습니다. 해당 사항에 대해 더 알아보기 위해 이슈를 따로 만들 예정입니다.
- https를 고려해 설계했기 때문에 session storage의 token은 expired time이 될 것이고 refresh token은 header에 정해주지 않아도 알아서 붙어 있는 cookie가 될 것입니다
- Switch 밖에 있는 Route는 useEffect를 찍지 않고, Switch 안에 있는 Route는 useEffect를 찍는 것 때문에 privateRoute에서 비동기를 처리하지 않고 loadPage component를 따로 만들어서 그곳에서 처리해 주었습니다. 위와 같은 현상이 일어나는 정확한 원인은 아직 모르겠습니다.
- 보통 상태관리로 로직을 처리하는데 이번 프로젝트의  특징에 맞게 loadPage라는 component로 따로 분리한 게 맞는지는 잘 모르겠습니다.
[### 스크린 샷]

[issue | close] #[ISSUE_NUMBER]
