### PR TITLE
[Refactor] Lazy Loading 설정을 통한 초기 렌더링 최적화

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -9,9 +9,11 @@ import React, { lazy, Suspense } from 'react';
 import { Switch, Route, Redirect } from 'react-router-dom';
 import styled, { ThemeProvider } from 'styled-components';
 
+import LoadAnimation from '@components/Loading';
+import { LoadingPage } from '@pages/index';
+
 const MainPage = lazy(() => import('@pages/MainPage'));
 const LoadPage = lazy(() => import('@pages/LoadPage'));
-const LoadingPage = lazy(() => import('@pages/LoadingPage'));
 const RankingPage = lazy(() => import('@pages/RankingPage'));
 const SignInPage = lazy(() => import('@pages/SignInPage'));
 const SignUpPage = lazy(() => import('@pages/SignUpPage'));
@@ -35,7 +37,7 @@ const App: React.FC = () => {
       <ThemeProvider theme={myTheme}>
         <GlobalStore>
           <ContentWrapper>
-            <Suspense fallback={<p>...Loading</p>}>
+            <Suspense fallback={<LoadAnimation />}>
               <Snackbar />
               <Header />
               <Switch>
@@ -55,7 +57,7 @@ const App: React.FC = () => {
                 component={ReviewSubmitPage}
               />
               <Route path="/map/ranking" render={() => <RankingPage />} />
-              <Route path="/map/signin" component={SignInPage} />
+              <Route path="/map/signin" render={() => <SignInPage />} />
               <Route path="/map/signup" render={() => <SignUpPage />} />
               <PrivateRoute
                 path="/profile/update-address"

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-children-prop */
 import {
   NotFoundPage,
   MainPage,

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,15 +1,3 @@
-import {
-  NotFoundPage,
-  MainPage,
-  ReviewSubmitPage,
-  LoadPage,
-  RankingPage,
-  SignInPage,
-  LoadingPage,
-  SignUpPage,
-  ProfilePage,
-  ProfileAddressPage,
-} from '@pages/index';
 import { GlobalStore } from '@stores/index';
 import GlobalStyle from '@styledComponents/GlobalStyle';
 import myTheme from '@styledComponents/theme';
@@ -17,9 +5,20 @@ import Header from '@components/Header/index';
 import Snackbar from '@components/Snackbar';
 import PrivateRoute from '@routes/PrivateRoute';
 
-import React from 'react';
+import React, { lazy, Suspense } from 'react';
 import { Switch, Route, Redirect } from 'react-router-dom';
 import styled, { ThemeProvider } from 'styled-components';
+
+const MainPage = lazy(() => import('@pages/MainPage'));
+const LoadPage = lazy(() => import('@pages/LoadPage'));
+const LoadingPage = lazy(() => import('@pages/LoadingPage'));
+const RankingPage = lazy(() => import('@pages/RankingPage'));
+const SignInPage = lazy(() => import('@pages/SignInPage'));
+const SignUpPage = lazy(() => import('@pages/SignUpPage'));
+const ProfilePage = lazy(() => import('@pages/ProfilePage'));
+const ProfileAddressPage = lazy(() => import('@pages/ProfileAddressPage'));
+const ReviewSubmitPage = lazy(() => import('@pages/ReviewSubmitPage'));
+const NotFoundPage = lazy(() => import('@pages/NotFoundPage'));
 
 const ContentWrapper = styled.div`
   width: 100%;
@@ -36,31 +35,33 @@ const App: React.FC = () => {
       <ThemeProvider theme={myTheme}>
         <GlobalStore>
           <ContentWrapper>
-            <Snackbar />
-            <Header />
-            <Switch>
-              <Route
-                exact
-                path="/"
-                component={() => <Redirect to={{ pathname: '/map' }} />}
+            <Suspense fallback={<p>...Loading</p>}>
+              <Snackbar />
+              <Header />
+              <Switch>
+                <Route
+                  exact
+                  path="/"
+                  component={() => <Redirect to={{ pathname: '/map' }} />}
+                />
+                <Route path="/map" render={() => <MainPage />} />
+                <Route path="/github/callback" render={() => <LoadingPage />} />
+                <Route path="/loading" render={() => <LoadPage />} />
+                <PrivateRoute path="/profile" component={ProfilePage} />
+                <Route render={() => <NotFoundPage />} />
+              </Switch>
+              <PrivateRoute
+                path="/map/write-review"
+                component={ReviewSubmitPage}
               />
-              <Route path="/map" render={() => <MainPage />} />
-              <Route path="/github/callback" render={() => <LoadingPage />} />
-              <Route path="/loading" render={() => <LoadPage />} />
-              <PrivateRoute path="/profile" component={ProfilePage} />
-              <Route render={() => <NotFoundPage />} />
-            </Switch>
-            <PrivateRoute
-              path="/map/write-review"
-              component={ReviewSubmitPage}
-            />
-            <Route path="/map/ranking" render={() => <RankingPage />} />
-            <Route path="/map/signin" component={SignInPage} />
-            <Route path="/map/signup" render={() => <SignUpPage />} />
-            <PrivateRoute
-              path="/profile/update-address"
-              component={ProfileAddressPage}
-            />
+              <Route path="/map/ranking" render={() => <RankingPage />} />
+              <Route path="/map/signin" component={SignInPage} />
+              <Route path="/map/signup" render={() => <SignUpPage />} />
+              <PrivateRoute
+                path="/profile/update-address"
+                component={ProfileAddressPage}
+              />
+            </Suspense>
           </ContentWrapper>
         </GlobalStore>
       </ThemeProvider>


### PR DESCRIPTION
### 🔨 작업 내용 설명
- Router 기반 Page Loading을 지연 로딩으로 진행되도록 설정

### 📑 구현한 내용
- 불 필요한 ESLINT disable 예외 처리 삭제
- Router 기반 Page Lazy Loading 설정(Suspense 설정)

[### 스크린 샷]
- 아래 화면에서 볼 수 있듯이, 느린 3G로 네트워크 성능 테스트 결과 초기 로딩 시간이 절반으로 감소하였으며, Bundle size가 51KB에서 200B 수준으로 감소한 것을 확인할 수 있다.
- 또한, Lighthouse 체크 결과 성능 수준에서 TTI 가 적은 수준이지만 개선된 것을 확인할 수 있다.
- 아래 화면이 잘 보이지 않을 경우 Notion 링크 참고
  - 링크 : https://www.notion.so/Lazy-Loading-329d88595d66464691d78cf802783113

![image](https://user-images.githubusercontent.com/31230442/143282241-038dfff7-df5e-44ad-ae0d-d3de4d8f8c30.png)
![image](https://user-images.githubusercontent.com/31230442/143282263-4a9d90eb-70f8-4417-8014-a50d563ba9d7.png)


close #162 
