### PR TITLE
[Feat] publicRoute만들기

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -46,15 +46,24 @@ const App: React.FC = () => {
                   path="/"
                   component={() => <Redirect to={{ pathname: '/map' }} />}
                 />
-                <Route path="/map" render={() => <MainPage />} />
+                <PrivateRoute
+                  path="/map"
+                  component={MainPage}
+                  needSignIn={false}
+                />
                 <Route path="/github/callback" render={() => <LoadingPage />} />
                 <Route path="/loading" render={() => <LoadPage />} />
-                <PrivateRoute path="/profile" component={ProfilePage} />
+                <PrivateRoute
+                  path="/profile"
+                  component={ProfilePage}
+                  needSignIn={true}
+                />
                 <Route render={() => <NotFoundPage />} />
               </Switch>
               <PrivateRoute
                 path="/map/write-review"
                 component={ReviewSubmitPage}
+                needSignIn={true}
               />
               <Route path="/map/ranking" render={() => <RankingPage />} />
               <Route path="/map/signin" render={() => <SignInPage />} />
@@ -62,6 +71,7 @@ const App: React.FC = () => {
               <PrivateRoute
                 path="/profile/update-address"
                 component={ProfileAddressPage}
+                needSignIn={true}
               />
             </Suspense>
           </ContentWrapper>

--- a/client/src/components/Header/index.tsx
+++ b/client/src/components/Header/index.tsx
@@ -84,7 +84,6 @@ const Header: React.FC = () => {
           <ProfileWrapper>
             <ReviewButton
               onClick={() => {
-                console.log(location);
                 routeHistory('/map/write-review');
               }}
             >

--- a/client/src/controllers/loadController.ts
+++ b/client/src/controllers/loadController.ts
@@ -12,7 +12,6 @@ const refreshTokenUser = async (auth, setAuth, routeHistory, location) => {
 
   if (!continueMember) {
     setAuth({
-      ...auth,
       isLoggedin: false,
       oauth_email: '',
       address: '',
@@ -46,7 +45,6 @@ const refreshTokenUser = async (auth, setAuth, routeHistory, location) => {
     const userInfo: IAPIResult<IUser | Record<string, never>> =
       await userInfoResponse.json();
     setAuth({
-      ...auth,
       isLoggedin: true,
       oauth_email: userInfo.result.oauth_email,
       address: userInfo.result.address,

--- a/client/src/controllers/signInController.ts
+++ b/client/src/controllers/signInController.ts
@@ -64,7 +64,6 @@ const isMember = (
     sessionStorage.setItem('jwt', userInfo.result.jwtToken);
     sessionStorage.setItem('refreshToken', userInfo.result.refreshToken);
     setAuth({
-      ...auth,
       isLoggedin: true,
       oauth_email: userInfo.result.oauthEmail,
       address: userInfo.result.address,

--- a/client/src/routes/PrivateRoute.tsx
+++ b/client/src/routes/PrivateRoute.tsx
@@ -6,18 +6,23 @@ import { authState } from '@stores/atoms';
 
 const PrivateRoute: React.FC<RouterProps> = ({
   component: Component,
+  needSignIn: needSignIn,
   ...rest
 }) => {
   const auth = useRecoilValue(authState);
   const location = useLocation();
 
-  const checkAll = (props) => {
+  const checkAll = () => {
     try {
       const token = sessionStorage.getItem('jwt');
 
       if (!token) {
         //로그인을 안 한 상태
-        return <Redirect to={{ pathname: '/map/signin' }} />;
+        if (needSignIn) {
+          return <Redirect to={{ pathname: '/map/signin' }} />;
+        } else {
+          return <Component />;
+        }
       }
       if (!auth.isLoggedin) {
         //로그인은 했지만 새로고침
@@ -29,7 +34,7 @@ const PrivateRoute: React.FC<RouterProps> = ({
         return <Redirect to={{ pathname: '/loading', state: location }} />;
       } else {
         //로그인한 상태이며 token이 유효한 상태
-        return <Component {...props} />;
+        return <Component />;
       }
     } catch (error) {
       alert(error);


### PR DESCRIPTION
### 🔨 작업 내용 설명
로그인 기능이 필요한 페이지 이외의 페이지들에 할당할 publicRoute 만들기

### 📑 구현한 내용

-  [x] publicRoute 만들기

### 🚧 주의 사항

publicRoute 파일을 따로 만들면 privateRoute와 겹치는 부분이 많아서 props를 추가로 전달하는 것으로 해결
privateRoute에서 추가한 prop은 boolean을 받는데 로그인이 필요한 페이지와 로그인이 필요하지는 않지만 사용자 정보를 사용하는 페이지를 나누기 위해서 사용했습니다.

[### 스크린 샷]

[issue | close] #[ISSUE_NUMBER]
