### PR TITLE
[Feat] API 경계좌표 Cache-Control 헤더 추가

### DIFF
--- a/client/src/hooks/cacheProvider.ts
+++ b/client/src/hooks/cacheProvider.ts
@@ -8,8 +8,7 @@ interface ICacheItem {
 }
 
 const isPolygonKey = (key: string) => {
-  if (key.includes('$req') || key.includes('$err')) return false;
-  return key.includes('polygon');
+  return key.startsWith(`${process.env.REACT_APP_API_URL}/api/map/polygon`);
 };
 
 const cacheProvider = (

--- a/server/src/api/mapController.ts
+++ b/server/src/api/mapController.ts
@@ -4,6 +4,7 @@ import logger from '@loaders/loggerLoader';
 import express, { Request, Response, RequestHandler } from 'express';
 
 const router: express.Router = express.Router();
+const POLYGON_MAX_AGE = 60 * 60 * 1;
 
 router.get('/polygon', (async (req: Request, res: Response) => {
   const address = req.query.address as string;
@@ -16,6 +17,7 @@ router.get('/polygon', (async (req: Request, res: Response) => {
       address,
       scope as 'big' | 'medium' | 'small',
     );
+    res.setHeader('Cache-Control', `max-age=${POLYGON_MAX_AGE}`);
     res.status(200).json(makeApiResponse(paths, ''));
   } catch (error) {
     const err = error as Error;


### PR DESCRIPTION
### 🔨 작업 내용 설명
- 경계좌표를 보낼 때(`/api/map/polygon`) `Cache-Control: max-age=<seconds>` 헤더 추가하여 HTTP를 활용한 캐싱 전략 사용

### 📑 구현한 내용
- `/api/map/polygon` 응답에 `Cache-Control` 헤더 추가
- SWR을 활용한 메모리 캐싱은 유지

### 🚧 주의 사항
- SWR 캐싱을 걷어내려고 했는데 다음과 같은 현상이 발생하여 유지하기로 결정하였습니다. 
- 처음 (디스크 캐시)에서 좌표들을 불러올 때는 수 ms 이내로 콘텐트가 다운로드되어 매우 빠릅니다. 
- 하지만 용량이 좀 큰 지역은 두번째 요청 이후로 똑같이 (디스크 캐시)에서 불러옴에도 수십~150ms 정도가 걸려 느려집니다. (16GB RAM, SSD 사용중입니다.)
- 왜 두번째 이후 요청은 디스크에서 불러옴에도 불구하고 시간이 더 오래걸리는지 원인은 규명하지 못했습니다. (디스크 캐시에서 불러온 데이터를 저장하는 메모리 공간도 로컬스토리지처럼 용량제한이 있는건지, 아니면 다른 원인인지 추정만 할뿐입니다)
- 결론적으로 LFU 메모리 캐시를 사용한 캐싱 전략은 여전히 유효할 것으로 보입니다. 브라우저가 대체 무슨 짓을 하는지, 파일시스템이 네트워크보다 월등히 우월하지는 않군요.

### 스크린 샷
![스크린샷(368)](https://user-images.githubusercontent.com/24454874/143603400-231c39d8-f97b-4516-9ac4-eafb6ab2bcba.png)

close #174 
