### PR TITLE
[Refactor] https_cookie 구현 리팩토링

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -4,6 +4,7 @@ import myTheme from '@styledComponents/theme';
 import Header from '@components/Header/index';
 import Snackbar from '@components/Snackbar';
 import PrivateRoute from '@routes/PrivateRoute';
+import { getOptions } from '@utils/common';
 
 import React, { lazy, Suspense, useEffect } from 'react';
 import { Switch, Route, Redirect } from 'react-router-dom';
@@ -33,10 +34,10 @@ const ContentWrapper = styled.div`
 const App: React.FC = () => {
   useEffect(() => {
     const deleteCookie = () => {
-      fetch(`${process.env.REACT_APP_API_URL as string}/api/auth/unload`, {
-        method: 'GET',
-        credentials: 'include',
-      });
+      fetch(
+        `${process.env.REACT_APP_API_URL as string}/api/auth/unload`,
+        getOptions('GET', undefined, 'same-origin'),
+      );
     };
     window.addEventListener('unload', deleteCookie);
     return () => {

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -36,7 +36,7 @@ const App: React.FC = () => {
     const deleteCookie = () => {
       fetch(
         `${process.env.REACT_APP_API_URL as string}/api/auth/unload`,
-        getOptions('GET', undefined, 'same-origin'),
+        getOptions('GET', undefined, 'include'),
       );
     };
     window.addEventListener('unload', deleteCookie);

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -4,6 +4,7 @@ import myTheme from '@styledComponents/theme';
 import Header from '@components/Header/index';
 import Snackbar from '@components/Snackbar';
 import PrivateRoute from '@routes/PrivateRoute';
+import ProtectRoute from '@routes/ProtectRoute';
 import { getOptions } from '@utils/common';
 
 import React, { lazy, Suspense, useEffect } from 'react';
@@ -66,7 +67,7 @@ const App: React.FC = () => {
                   needSignIn={false}
                 />
                 <Route path="/github/callback" render={() => <LoadingPage />} />
-                <Route path="/loading" render={() => <LoadPage />} />
+                <ProtectRoute path="/loading" component={LoadPage} />
                 <PrivateRoute
                   path="/profile"
                   component={ProfilePage}
@@ -81,7 +82,7 @@ const App: React.FC = () => {
               />
               <Route path="/map/ranking" render={() => <RankingPage />} />
               <Route path="/map/signin" render={() => <SignInPage />} />
-              <Route path="/map/signup" render={() => <SignUpPage />} />
+              <ProtectRoute path="/map/signup" component={SignUpPage} />
               <PrivateRoute
                 path="/profile/update-address"
                 component={ProfileAddressPage}

--- a/client/src/components/Header/index.tsx
+++ b/client/src/components/Header/index.tsx
@@ -21,6 +21,7 @@ import {
 import React, { useEffect, useState, useCallback } from 'react';
 import { useLocation } from 'react-router-dom';
 import useHistoryRouter from '@hooks/useHistoryRouter';
+import { getOptions } from '@utils/common';
 import { useRecoilState } from 'recoil';
 
 const Header: React.FC = () => {
@@ -31,11 +32,10 @@ const Header: React.FC = () => {
   const [auth, setAuth] = useRecoilState(authState);
 
   const onLogoutClick = useCallback(() => {
-    fetch(`${process.env.REACT_APP_API_URL as string}/api/auth/logout`, {
-      method: 'GET',
-      credentials: 'include',
-      mode: 'cors',
-    });
+    fetch(
+      `${process.env.REACT_APP_API_URL as string}/api/auth/logout`,
+      getOptions('GET', undefined, 'include'),
+    );
     sessionStorage.removeItem('timer');
     setAuth({
       isLoggedin: false,

--- a/client/src/controllers/authController.ts
+++ b/client/src/controllers/authController.ts
@@ -12,7 +12,7 @@ token이 잘못되었거나 access와 refresh token이 만료된 경우로 모�
 const newIssuedToken = async () => {
   const newTokenRes = await fetch(
     `${process.env.REACT_APP_API_URL as string}/api/auth/refresh`,
-    getOptions('GET', undefined, 'same-origin'),
+    getOptions('GET', undefined, 'include'),
   );
 
   const newToken: IAPIResult<IToken | Record<string, never>> =

--- a/client/src/controllers/authController.ts
+++ b/client/src/controllers/authController.ts
@@ -1,6 +1,6 @@
 import { IAPIResult } from '@myTypes/Common';
 import { IToken } from '@myTypes/User';
-
+import { getOptions } from '@utils/common';
 /*
 2021-11-24
 문혜현
@@ -12,11 +12,7 @@ token이 잘못되었거나 access와 refresh token이 만료된 경우로 모�
 const newIssuedToken = async () => {
   const newTokenRes = await fetch(
     `${process.env.REACT_APP_API_URL as string}/api/auth/refresh`,
-    {
-      method: 'GET',
-      credentials: 'include',
-      mode: 'cors',
-    },
+    getOptions('GET', undefined, 'same-origin'),
   );
 
   const newToken: IAPIResult<IToken | Record<string, never>> =

--- a/client/src/controllers/loadController.ts
+++ b/client/src/controllers/loadController.ts
@@ -1,6 +1,7 @@
 import { IUser } from '@myTypes/User';
 import { IAPIResult } from '@myTypes/Common';
 import { newIssuedToken } from '@controllers/authController';
+import { getOptions } from '@utils/common';
 
 const refreshTokenUser = async (auth, setAuth, routeHistory, location) => {
   /*
@@ -35,11 +36,7 @@ const refreshTokenUser = async (auth, setAuth, routeHistory, location) => {
     */
     const userInfoResponse = await fetch(
       `${process.env.REACT_APP_API_URL as string}/api/auth/info`,
-      {
-        method: 'GET',
-        credentials: 'include',
-        mode: 'cors',
-      },
+      getOptions('GET', undefined, 'same-origin'),
     );
     const userInfo: IAPIResult<IUser | Record<string, never>> =
       await userInfoResponse.json();

--- a/client/src/controllers/loadController.ts
+++ b/client/src/controllers/loadController.ts
@@ -36,7 +36,7 @@ const refreshTokenUser = async (auth, setAuth, routeHistory, location) => {
     */
     const userInfoResponse = await fetch(
       `${process.env.REACT_APP_API_URL as string}/api/auth/info`,
-      getOptions('GET', undefined, 'same-origin'),
+      getOptions('GET', undefined, 'include'),
     );
     const userInfo: IAPIResult<IUser | Record<string, never>> =
       await userInfoResponse.json();

--- a/client/src/controllers/sidebarController.ts
+++ b/client/src/controllers/sidebarController.ts
@@ -1,6 +1,7 @@
 import { IAPIResult } from '@myTypes/Common';
 import { IReviewContent, IReviewSubmit } from '@myTypes/Review';
 import { confirmAlert } from 'react-confirm-alert';
+import { getOptions } from '@utils/common';
 
 import 'react-confirm-alert/src/react-confirm-alert.css';
 import '@components/ReviewModal/alertStyle.css';
@@ -15,15 +16,10 @@ const submitReview = (
       {
         label: '제출',
         onClick: () => {
-          const requestHeaders: HeadersInit = new Headers();
-          requestHeaders.set('Content-Type', 'application/json');
-          requestHeaders.set('token', sessionStorage.getItem('jwt') as string);
-
-          fetch(`${process.env.REACT_APP_API_URL}/api/review`, {
-            method: 'POST',
-            headers: requestHeaders,
-            body: JSON.stringify(data),
-          }).then((res) => res.json());
+          fetch(
+            `${process.env.REACT_APP_API_URL}/api/review`,
+            getOptions('POST', data, 'same-origin'),
+          ).then((res) => res.json());
           routeHistory('/map');
         },
       },
@@ -47,10 +43,6 @@ const fetchContentData = async (
 ): Promise<IAPIResult<IReviewContent[] | []>> => {
   let fetchUrl = `${process.env.REACT_APP_API_URL}/api/review`;
 
-  const requestHeaders: HeadersInit = new Headers();
-  requestHeaders.set('Content-Type', 'application/json');
-  requestHeaders.set('token', sessionStorage.getItem('jwt') as string);
-
   switch (menu) {
     case 'myreview':
       fetchUrl += `/user?pageNum=${pageNum}&itemNum=${itemNum}`;
@@ -60,10 +52,7 @@ const fetchContentData = async (
       break;
   }
 
-  return await fetch(`${fetchUrl}`, {
-    method: 'GET',
-    headers: requestHeaders,
-  })
+  return await fetch(`${fetchUrl}`, getOptions('GET', undefined, 'same-origin'))
     .then(async (response) => {
       if (response.status === 200) {
         return await response.json();

--- a/client/src/controllers/sidebarController.ts
+++ b/client/src/controllers/sidebarController.ts
@@ -18,7 +18,7 @@ const submitReview = (
         onClick: () => {
           fetch(
             `${process.env.REACT_APP_API_URL}/api/review`,
-            getOptions('POST', data, 'same-origin'),
+            getOptions('POST', data, 'include'),
           ).then((res) => res.json());
           routeHistory('/map');
         },
@@ -52,7 +52,7 @@ const fetchContentData = async (
       break;
   }
 
-  return await fetch(`${fetchUrl}`, getOptions('GET', undefined, 'same-origin'))
+  return await fetch(`${fetchUrl}`, getOptions('GET', undefined, 'include'))
     .then(async (response) => {
       if (response.status === 200) {
         return await response.json();

--- a/client/src/controllers/signInController.ts
+++ b/client/src/controllers/signInController.ts
@@ -17,7 +17,7 @@ const getToken = async (): Promise<
   try {
     const userInfoResponse = await fetch(
       `${process.env.REACT_APP_API_URL as string}/api/auth/signin`,
-      getOptions('POST', { code }, 'same-origin'),
+      getOptions('POST', { code }, 'include'),
     );
     const userInfo: IAPIResult<IUser | Record<string, never>> =
       await userInfoResponse.json();

--- a/client/src/controllers/signInController.ts
+++ b/client/src/controllers/signInController.ts
@@ -45,6 +45,7 @@ const isMember = (
     routeHistory('/map/signup', {
       oauthEmail: userInfo.result.oauthEmail,
       image: userInfo.result.image,
+      isRoute: true,
     });
     return;
   }

--- a/client/src/controllers/signInController.ts
+++ b/client/src/controllers/signInController.ts
@@ -1,6 +1,7 @@
 import qs from 'qs';
 import { IAPIResult } from '@myTypes/Common';
 import { IUser } from '@myTypes/User';
+import { getOptions } from '@utils/common';
 
 const getToken = async (): Promise<
   [number, IAPIResult<IUser | Record<string, never>>]
@@ -16,16 +17,7 @@ const getToken = async (): Promise<
   try {
     const userInfoResponse = await fetch(
       `${process.env.REACT_APP_API_URL as string}/api/auth/signin`,
-      {
-        credentials: 'include',
-        mode: 'cors',
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-
-        body: JSON.stringify({ code }),
-      },
+      getOptions('POST', { code }, 'same-origin'),
     );
     const userInfo: IAPIResult<IUser | Record<string, never>> =
       await userInfoResponse.json();

--- a/client/src/controllers/signUpController.ts
+++ b/client/src/controllers/signUpController.ts
@@ -22,7 +22,7 @@ const signUpAdress = async (
         center: mapInfo.center,
         image: location.state.image,
       },
-      'same-origin',
+      'include',
     ),
   );
 

--- a/client/src/controllers/signUpController.ts
+++ b/client/src/controllers/signUpController.ts
@@ -4,6 +4,7 @@ import { IAPIResult } from '@myTypes/Common';
 import { ISignUp } from '@myTypes/User';
 import { IMapInfo } from '@myTypes/Map';
 import { IAuthInfo } from '@myTypes/User';
+import { getOptions } from '@utils/common';
 
 const signUpAdress = async (
   mapInfo: IMapInfo,
@@ -12,21 +13,17 @@ const signUpAdress = async (
 ): Promise<[number, IAPIResult<ISignUp | Record<string, never>>]> => {
   const response = await fetch(
     `${process.env.REACT_APP_API_URL}/api/auth/signup`,
-    {
-      method: 'POST',
-      credentials: 'include',
-      mode: 'cors',
-      headers: {
-        'Content-Type': 'application/json;charset=utf-8',
-      },
-      body: JSON.stringify({
+    getOptions(
+      'POST',
+      {
         oauthEmail: location.state.oauthEmail,
         address: mapInfo.address,
         code: mapInfo.code,
         center: mapInfo.center,
         image: location.state.image,
-      }),
-    },
+      },
+      'same-origin',
+    ),
   );
 
   const userInfo: IAPIResult<ISignUp | Record<string, never>> =

--- a/client/src/routes/PrivateRoute.tsx
+++ b/client/src/routes/PrivateRoute.tsx
@@ -25,7 +25,11 @@ const PrivateRoute: React.FC<RouterProps> = ({
       }
       if (!auth.isLoggedin) {
         //로그인은 했지만 새로고침
-        return <Redirect to={{ pathname: '/loading', state: location }} />;
+        return (
+          <Redirect
+            to={{ pathname: '/loading', state: { isRoute: true, ...location } }}
+          />
+        );
       }
 
       const now = new Date();
@@ -35,7 +39,11 @@ const PrivateRoute: React.FC<RouterProps> = ({
         Number(process.env.REACT_APP_TIMER)
       ) {
         //로그인한 상태인데 token이 만료
-        return <Redirect to={{ pathname: '/loading', state: location }} />;
+        return (
+          <Redirect
+            to={{ pathname: '/loading', state: { isRoute: true, ...location } }}
+          />
+        );
       } else {
         //로그인한 상태이며 token이 유효한 상태
         return <Component />;

--- a/client/src/routes/ProtectRoute.tsx
+++ b/client/src/routes/ProtectRoute.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { Route, Redirect, useLocation, RouterProps } from 'react-router-dom';
+
+const ProtectRoute: React.FC<RouterProps> = ({
+  component: Component,
+  ...rest
+}) => {
+  const location = useLocation();
+
+  const checkRoute = () => {
+    return location.state?.isRoute ? <Component /> : <Redirect to="/map" />;
+  };
+
+  return <Route {...rest} render={checkRoute} />;
+};
+
+export default ProtectRoute;

--- a/client/src/utils/common.ts
+++ b/client/src/utils/common.ts
@@ -73,6 +73,22 @@ const fetcher = async <T>(info: RequestInfo, init?: RequestInit) => {
   return json.result;
 };
 
+const getOptions = <T>(
+  fetchMethod: 'GET' | 'POST' | 'PATCH' | 'DELETE' | 'UPDATE',
+  data: T,
+  credential: 'omit' | 'same-origin' | 'include' = 'omit',
+): RequestInit => {
+  return {
+    method: fetchMethod,
+    mode: 'cors',
+    credentials: credential,
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(data),
+  };
+};
+
 export {
   calcTotal,
   calcDateDiff,
@@ -80,4 +96,5 @@ export {
   showSnackbar,
   getPrevPath,
   fetcher,
+  getOptions,
 };

--- a/server/src/api/authController.ts
+++ b/server/src/api/authController.ts
@@ -18,9 +18,10 @@ const router: express.Router = express.Router();
 
 router.post('/signin', (async (req: AuthRequest, res: Response) => {
   const { code } = req.body;
-  if (!code) throw new Error('비정상적인 접근입니다');
 
   try {
+    if (!code) throw new Error('비정상적인 접근입니다');
+
     const accessToken = await authService.getAccessToken(code);
     const oauthInfo = await authService.getOauthEmail(accessToken);
     if (!oauthInfo.oauthEmail) {

--- a/server/src/api/authController.ts
+++ b/server/src/api/authController.ts
@@ -10,6 +10,7 @@ import checkToken from '@middlewares/auth';
 import { makeApiResponse } from '@utils/index';
 import { AuthError } from '@utils/authErrorEnum';
 import { authErrCheck } from '@utils/authError';
+import { getCookieOption, removeCookie } from '@utils/index';
 import config from '@config/index';
 import { AuthRequest, UserInfo } from '@myTypes/User';
 import { AuthMiddleRequest, Token } from '@myTypes/User';
@@ -45,18 +46,17 @@ router.post('/signin', (async (req: AuthRequest, res: Response) => {
         image: isMember.image as string,
       };
 
-      res.cookie('token', jwtToken.token, {
-        httpOnly: true,
-        secure: true,
-        sameSite: 'none',
-        maxAge: Number(config.jwt_cookie_expire),
-      });
-      res.cookie('refreshToken', jwtToken.refreshToken, {
-        httpOnly: true,
-        secure: true,
-        sameSite: 'none',
-        maxAge: Number(config.jwt_refresh_cookie_expire),
-      });
+      res.cookie(
+        'token',
+        jwtToken.token,
+        getCookieOption(Number(config.jwt_cookie_expire)),
+      );
+
+      res.cookie(
+        'refreshToken',
+        jwtToken.refreshToken,
+        getCookieOption(Number(config.jwt_refresh_cookie_expire)),
+      );
 
       res.status(200).json(makeApiResponse(userInfo, '로그인에 성공했습니다.'));
     } else {
@@ -90,18 +90,16 @@ router.post('/signup', (async (req: Request, res: Response) => {
     await authService.saveUserInfo(newUserInfo);
     const jwtToken = jwt.sign({ oauth_email: oauthEmail });
 
-    res.cookie('token', jwtToken.token, {
-      httpOnly: true,
-      secure: true,
-      sameSite: 'none',
-      maxAge: Number(config.jwt_cookie_expire),
-    });
-    res.cookie('refreshToken', jwtToken.refreshToken, {
-      httpOnly: true,
-      secure: true,
-      sameSite: 'none',
-      maxAge: Number(config.jwt_refresh_cookie_expire),
-    });
+    res.cookie(
+      'token',
+      jwtToken.token,
+      getCookieOption(Number(config.jwt_cookie_expire)),
+    );
+    res.cookie(
+      'refreshToken',
+      jwtToken.refreshToken,
+      getCookieOption(Number(config.jwt_refresh_cookie_expire)),
+    );
 
     res.status(200).json(
       makeApiResponse(
@@ -123,8 +121,9 @@ router.get('/refresh', checkToken, (req: AuthMiddleRequest, res: Response) => {
     const refreshToken = (req.cookies as Token).refreshToken;
 
     if (!refreshToken) {
-      res.clearCookie('token');
-      return res.status(500).json(makeApiResponse({}, '토큰이 없습니다.'));
+      return removeCookie(res)
+        .status(500)
+        .json(makeApiResponse({}, '토큰이 없습니다.'));
     }
 
     const refreshVerify = jwt.verify(refreshToken, 'refreshToken');
@@ -134,9 +133,9 @@ router.get('/refresh', checkToken, (req: AuthMiddleRequest, res: Response) => {
     token과 refresh token 모두 만료되었을 때
     */
     if (refreshVerify == AuthError.TOKEN_EXPIRED) {
-      res.clearCookie('token');
-      res.clearCookie('refreshToken');
-      return res.status(500).json(makeApiResponse({}, '다시 로그인해 주세요.'));
+      return removeCookie(res)
+        .status(500)
+        .json(makeApiResponse({}, '다시 로그인해 주세요.'));
     }
 
     if (
@@ -150,12 +149,11 @@ router.get('/refresh', checkToken, (req: AuthMiddleRequest, res: Response) => {
       oauth_email: (refreshVerify as JwtPayload).oauth_email as string,
     });
 
-    res.cookie('token', newAccessToken.token, {
-      httpOnly: true,
-      secure: true,
-      sameSite: 'none',
-      maxAge: Number(config.jwt_cookie_expire),
-    });
+    res.cookie(
+      'token',
+      newAccessToken.token,
+      getCookieOption(Number(config.jwt_cookie_expire)),
+    );
 
     return res
       .status(200)
@@ -163,9 +161,9 @@ router.get('/refresh', checkToken, (req: AuthMiddleRequest, res: Response) => {
   } catch (error) {
     const err = error as Error;
     logger.error(err.message);
-    res.clearCookie('token');
-    res.clearCookie('refreshToken');
-    res.status(500).json(makeApiResponse({}, '다시 로그인해 주세요.'));
+    removeCookie(res)
+      .status(500)
+      .json(makeApiResponse({}, '다시 로그인해 주세요.'));
   }
 });
 
@@ -187,9 +185,7 @@ router.get(
           ),
         );
       } else {
-        res.clearCookie('token');
-        res.clearCookie('refreshToken');
-        res
+        removeCookie(res)
           .status(500)
           .json(
             makeApiResponse({}, '회원 정보를 불러오는데 오류가 발생했습니다'),
@@ -198,9 +194,7 @@ router.get(
     } catch (error) {
       const err = error as Error;
       logger.error(err.message);
-      res.clearCookie('token');
-      res.clearCookie('refreshToken');
-      res
+      removeCookie(res)
         .status(500)
         .json(
           makeApiResponse({}, '회원 정보를 불러오는데 오류가 발생했습니다.'),
@@ -210,35 +204,11 @@ router.get(
 );
 
 router.get('/logout', (req: Request, res: Response) => {
-  res.cookie('token', '', {
-    httpOnly: true,
-    secure: true,
-    sameSite: 'none',
-    maxAge: 0,
-  });
-  res.cookie('refreshToken', '', {
-    httpOnly: true,
-    secure: true,
-    sameSite: 'none',
-    maxAge: 0,
-  });
-  res.status(200).json({});
+  removeCookie(res).status(200).json({});
 });
 
 router.get('/unload', (req: Request, res: Response) => {
-  res.cookie('token', '', {
-    httpOnly: true,
-    secure: true,
-    sameSite: 'none',
-    maxAge: 0,
-  });
-  res.cookie('refreshToken', '', {
-    httpOnly: true,
-    secure: true,
-    sameSite: 'none',
-    maxAge: 0,
-  });
-  res.status(200).json({});
+  removeCookie(res).status(200).json({});
 });
 
 export default router;

--- a/server/src/middlewares/auth.ts
+++ b/server/src/middlewares/auth.ts
@@ -6,6 +6,7 @@ import { AuthMiddleRequest, Token } from '@myTypes/User';
 import { JwtPayload } from 'jsonwebtoken';
 import { AuthError } from '@utils/authErrorEnum';
 import { authErrCheck } from '@utils/authError';
+import { removeCookie } from '@utils/index';
 
 const checkToken = (
   req: AuthMiddleRequest,
@@ -16,8 +17,9 @@ const checkToken = (
 
   if (!token) {
     logger.error('토큰이 없습니다.');
-    res.clearCookie('refreshToken');
-    return res.status(500).json(makeApiResponse({}, '토큰이 없습니다.'));
+    return removeCookie(res)
+      .status(500)
+      .json(makeApiResponse({}, '토큰이 없습니다.'));
   }
 
   const user = jwt.verify(token);

--- a/server/src/utils/authError.ts
+++ b/server/src/utils/authError.ts
@@ -3,21 +3,21 @@ import { JwtPayload } from 'jsonwebtoken';
 import logger from '@loaders/loggerLoader';
 import { makeApiResponse } from '@utils/index';
 import { AuthError } from '@utils/authErrorEnum';
+import { removeCookie } from '@utils/index';
 
 const authErrCheck = (user: string | -3 | -2 | JwtPayload, res: Response) => {
-  res.clearCookie('token');
-  res.clearCookie('refreshToken');
-
   if (user === AuthError.TOKEN_INVALID) {
     logger.error('유효하지 않은 토큰입니다.');
-    return res
+    return removeCookie(res)
       .status(500)
       .json(makeApiResponse({}, '유효하지 않은 토큰입니다.'));
   }
 
   if ((user as JwtPayload).oauth_email === undefined) {
     logger.error('잘못된 토큰입니다.');
-    return res.status(500).json(makeApiResponse({}, '잘못된 토큰입니다.'));
+    return removeCookie(res)
+      .status(500)
+      .json(makeApiResponse({}, '잘못된 토큰입니다.'));
   }
 };
 

--- a/server/src/utils/index.ts
+++ b/server/src/utils/index.ts
@@ -1,3 +1,5 @@
+import { CookieOptions, Response } from 'express';
+
 const makeApiResponse = <T>(result: T, message: string) => {
   return {
     result,
@@ -15,4 +17,22 @@ const isRangeValid = (
   return true;
 };
 
-export { makeApiResponse, isRangeValid };
+const getCookieOption = (
+  maxAge: number,
+  sameSite: 'lax' | 'none' | 'strict' = 'none',
+): CookieOptions => {
+  return {
+    httpOnly: true,
+    secure: true,
+    sameSite: sameSite,
+    maxAge: maxAge,
+  };
+};
+
+const removeCookie = (res: Response): Response => {
+  res.cookie('token', '', getCookieOption(0, 'none'));
+  res.cookie('refreshToken', '', getCookieOption(0, 'none'));
+  return res;
+};
+
+export { makeApiResponse, isRangeValid, getCookieOption, removeCookie };


### PR DESCRIPTION
### 🔨 작업 내용 설명
https_cookie 리팩토링

### 📑 구현한 내용

- [x] 중복 함수 없애기
- [x] 필요 없는 속성 제거하기
- [x] credentials 속성 필요한 fetch 찾기

### 🚧 주의 사항

CORS가 걸리지 않는다는 것을 확인했기 때문에 Lax와 same-site를 옵션으로 주어 로그인 했을 때 응답 헤더에는 쿠키가 잘 있는 것을 확인했습니다. 하지만 애플리케이션에서는 보이지 않고 이후 client의 요청에서는 cookie가 담겨있지 않은 것을 볼 수 있었습니다. 이유는 아직 잘 모르겠습니다.

[### 스크린 샷]

[issue | close] #[ISSUE_NUMBER]
