### PR TITLE
[Feat] 직접 url을 쳤을 때 들어가지 못하게 막는 protectRoute

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -4,6 +4,7 @@ import myTheme from '@styledComponents/theme';
 import Header from '@components/Header/index';
 import Snackbar from '@components/Snackbar';
 import PrivateRoute from '@routes/PrivateRoute';
+import ProtectRoute from '@routes/ProtectRoute';
 import { getOptions } from '@utils/common';
 
 import React, { lazy, Suspense, useEffect } from 'react';
@@ -66,7 +67,7 @@ const App: React.FC = () => {
                   needSignIn={false}
                 />
                 <Route path="/github/callback" render={() => <LoadingPage />} />
-                <Route path="/loading" render={() => <LoadPage />} />
+                <ProtectRoute path="/loading" component={LoadPage} />
                 <PrivateRoute
                   path="/profile"
                   component={ProfilePage}
@@ -81,7 +82,7 @@ const App: React.FC = () => {
               />
               <Route path="/map/ranking" render={() => <RankingPage />} />
               <Route path="/map/signin" render={() => <SignInPage />} />
-              <Route path="/map/signup" render={() => <SignUpPage />} />
+              <ProtectRoute path="/map/signup" component={SignUpPage} />
               <PrivateRoute
                 path="/profile/update-address"
                 component={ProfileAddressPage}

--- a/client/src/controllers/signInController.ts
+++ b/client/src/controllers/signInController.ts
@@ -45,6 +45,7 @@ const isMember = (
     routeHistory('/map/signup', {
       oauthEmail: userInfo.result.oauthEmail,
       image: userInfo.result.image,
+      isRoute: true,
     });
     return;
   }

--- a/client/src/routes/PrivateRoute.tsx
+++ b/client/src/routes/PrivateRoute.tsx
@@ -25,7 +25,11 @@ const PrivateRoute: React.FC<RouterProps> = ({
       }
       if (!auth.isLoggedin) {
         //로그인은 했지만 새로고침
-        return <Redirect to={{ pathname: '/loading', state: location }} />;
+        return (
+          <Redirect
+            to={{ pathname: '/loading', state: { isRoute: true, ...location } }}
+          />
+        );
       }
 
       const now = new Date();
@@ -35,7 +39,11 @@ const PrivateRoute: React.FC<RouterProps> = ({
         Number(process.env.REACT_APP_TIMER)
       ) {
         //로그인한 상태인데 token이 만료
-        return <Redirect to={{ pathname: '/loading', state: location }} />;
+        return (
+          <Redirect
+            to={{ pathname: '/loading', state: { isRoute: true, ...location } }}
+          />
+        );
       } else {
         //로그인한 상태이며 token이 유효한 상태
         return <Component />;

--- a/client/src/routes/ProtectRoute.tsx
+++ b/client/src/routes/ProtectRoute.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { Route, Redirect, useLocation, RouterProps } from 'react-router-dom';
+
+const ProtectRoute: React.FC<RouterProps> = ({
+  component: Component,
+  ...rest
+}) => {
+  const location = useLocation();
+
+  const checkRoute = () => {
+    return location.state?.isRoute ? <Component /> : <Redirect to="/map" />;
+  };
+
+  return <Route {...rest} render={checkRoute} />;
+};
+
+export default ProtectRoute;

--- a/server/src/api/authController.ts
+++ b/server/src/api/authController.ts
@@ -18,9 +18,10 @@ const router: express.Router = express.Router();
 
 router.post('/signin', (async (req: AuthRequest, res: Response) => {
   const { code } = req.body;
-  if (!code) throw new Error('비정상적인 접근입니다');
 
   try {
+    if (!code) throw new Error('비정상적인 접근입니다');
+
     const accessToken = await authService.getAccessToken(code);
     const oauthInfo = await authService.getOauthEmail(accessToken);
     if (!oauthInfo.oauthEmail) {


### PR DESCRIPTION
### 🔨 작업 내용 설명
직접 url을 쳤을 때 들어가지 못하게 막는 protectRoute

### 📑 구현한 내용

- [x] /loading인 loadPage 막기
- [x] /map/signup 막기

### 🚧 주의 사항

/github/callback은 github에서 redirect해주어야 하기 때문에 custom Route를 적용하지 않지만 authroization code가 필요하기 때문에 잘못된 접근은 모두 백엔드에서 로그인페이지로 가도록 만들어 놓았습니다.
signupPage(/map/signup)와 loadPage (/loading)에 적용하였습니다.
location.state로 구분하였고 새로고침하면 location.state 값이 남아있어서 그대로 유지되는 것은 signup 페이지에 유용합니다.
url에 그대로 치면 location.state가 없기 때문에 안되고 console 창에 history.push를 해도 컴포넌트가 렌더링되지 않아서 위험이 적음
로그인 되어있지 않은 상황에서는 url을 직접 치면 모두 튕겨냅니다.
로그인 되어 있는 상태에서 loading 페이지는 privateRoute에 의해 사용되기 때문에 loadingPage에는 직접 못들어가면서 map으로 redirect되고 이때, privateRoute가 작동되면서 로그인은 유지되는 현상(프로필이 유지됨)을 볼 수 있습니다.

[### 스크린 샷]

[issue | close] #[ISSUE_NUMBER]
