### PR TITLE
fix: #208 - 마커 아래 클릭 불가 공간이 생기는 이슈

### DIFF
--- a/client/src/components/Map/markerStyle.css
+++ b/client/src/components/Map/markerStyle.css
@@ -34,7 +34,6 @@
 
 .customoverlay {
   position: relative;
-  bottom: 25px;
   border-radius: 6px;
   border: 1px solid #ccc;
   border-bottom: 2px solid #ddd;
@@ -44,10 +43,6 @@
   float: left;
   user-select: none;
   cursor: pointer;
-}
-
-.customoverlay_large {
-  bottom: 75px;
 }
 
 .customoverlay:nth-of-type(n) {


### PR DESCRIPTION
- `yAnchor: 1` 옵션을 주어 해결
- 이에 따른 CSS 코드 수정 및 중복 코드 개선

## [ISSUE_TAG] Title

### 🔨 작업 내용 설명
- 마커 아래 클릭 불가능한 공간이 생기는 이슈 해결

### 📑 구현한 내용
- `kakao.maps.CustomOverlay` 생성자에 `yAnchor: 1` 옵션을 주어 해결
- 이에 따른 불필요해진 CSS 코드 제거
- 이에 따른 `markerController` 중복 코드 리팩토링

### 🚧 주의 사항
- `yAnchor` 옵션은 마커를 지정된 위치에서 얼마만큼 위로 띄울지 결정하는 옵션으로 "그려질 내용의 높이에 대한 비율"로 설정됩니다. (`[0, 1]`의 값을 가질 수 있습니다.)
- 기본값은 0.5이며, 이전에는 마커에 `bottom: <n>px; ` 룰을 하드코딩해 놓아서 발생한 문제였습니다. 
- `yAnchor`를 통해 해결하면 마커 아래 세모의 꼭짓점이 지역의 중앙점이 아니게 됩니다. 그보다 살짝 낮은 곳에 찍히게 되지만 큰 차이는 없을 것이라고 생각됩니다. 

### 스크린 샷
![marker_unclickable](https://user-images.githubusercontent.com/24454874/144055594-0f47e948-1656-4c75-8d62-d37ec629d994.gif)

close #208 
