### PR TITLE
[Fix] 모달을 띄울 때 배경이 Suspense로 인해 재렌더링되는 이슈

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -43,9 +43,9 @@ const App: React.FC = () => {
       <GlobalStyle />
       <ThemeProvider theme={myTheme}>
         <GlobalStore>
+          <Snackbar />
+          <Header />
           <Suspense fallback={<LoadAnimation />}>
-            <Snackbar />
-            <Header />
             <Switch>
               <Route
                 exact
@@ -66,6 +66,8 @@ const App: React.FC = () => {
               />
               <Route render={() => <NotFoundPage />} />
             </Switch>
+          </Suspense>
+          <Suspense fallback={null}>
             <PrivateRoute
               path="/:back/write-review"
               component={ReviewSubmitModal}


### PR DESCRIPTION
### 🔨 작업 내용 설명
- Suspense를 둘로 나누어서 해결
- 주소창에 `/map/write-review`를 입력했을 때 맵이 완전히 렌더링되지 않는 문제도 얼결에 해결

close #215
