### PR TITLE
[Fix] custon route switch 안과 밖이 겹치는 것 처리

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -4,12 +4,12 @@ import myTheme from '@styledComponents/theme';
 import Snackbar from '@components/Snackbar';
 import PrivateRoute from '@routes/PrivateRoute';
 import ProtectRoute from '@routes/ProtectRoute';
+import PublicRoute from '@routes/PublicRoute';
 
 import React, { lazy, Suspense } from 'react';
 import { Switch, Route, Redirect } from 'react-router-dom';
 import { ThemeProvider } from 'styled-components';
 
-import LoadAnimation from '@components/Loading';
 import Header from '@components/Header';
 import { LoadingPage } from '@pages/index';
 
@@ -29,7 +29,7 @@ const App: React.FC = () => {
       <GlobalStyle />
       <ThemeProvider theme={myTheme}>
         <GlobalStore>
-          <Suspense fallback={<LoadAnimation />}>
+          <Suspense fallback={null}>
             <Snackbar />
             <Header />
             <Switch>
@@ -38,7 +38,7 @@ const App: React.FC = () => {
                 path="/"
                 component={() => <Redirect to={{ pathname: '/map' }} />}
               />
-              <Route path="/map" render={() => <MainPage />} />
+              <PublicRoute path="/map" component={MainPage} />
               <Route path="/github/callback" render={() => <LoadingPage />} />
               <ProtectRoute path="/loading" component={LoadPage} />
               <PrivateRoute path="/profile" component={ProfilePage} />
@@ -50,10 +50,10 @@ const App: React.FC = () => {
             />
             <Route path="/:back/ranking" render={() => <RankingModal />} />
             <Route path="/:back/signin" render={() => <SignInModal />} />
-            <ProtectRoute path="/:back/signup" compoent={SignUpModal} />
-            <PrivateRoute
-              path="/:back/update-address"
-              component={ProfileAddressModal}
+            <ProtectRoute path="/map/signup" component={SignUpModal} />
+            <Route
+              path="/profile/update-address"
+              render={() => <ProfileAddressModal />}
             />
           </Suspense>
         </GlobalStore>

--- a/client/src/modals/ReviewSubmitModal/index.tsx
+++ b/client/src/modals/ReviewSubmitModal/index.tsx
@@ -23,9 +23,10 @@ import useHistoryRouter from '@hooks/useHistoryRouter';
 
 const ReviewModal: React.FC = () => {
   const routeHistory = useHistoryRouter();
+  const auth = useRecoilValue(authState);
   const [reviewData, setReviewData] = useState<IReviewSubmit>({
-    address: useRecoilValue(authState).address,
-    oauth_email: useRecoilValue(authState).oauthEmail,
+    address: auth.address,
+    oauth_email: auth.oauthEmail,
     text: '',
     categories: {
       safety: 1,
@@ -83,7 +84,7 @@ const ReviewModal: React.FC = () => {
     <Modal>
       <TitleDiv>
         <FontAwesomeIcon icon={faMapMarkerAlt}></FontAwesomeIcon>
-        <span style={{ marginLeft: '10px' }}>{reviewData.address}</span>
+        <span style={{ marginLeft: '10px' }}>{auth.address}</span>
       </TitleDiv>
       <StarRateDiv>{RatingStars}</StarRateDiv>
       <TextAreaDiv>

--- a/client/src/routes/PrivateModalRoute.tsx
+++ b/client/src/routes/PrivateModalRoute.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Route, Redirect, RouterProps } from 'react-router-dom';
+import { useRecoilValue } from 'recoil';
+import { authState } from '@stores/atoms';
+
+const PrivateModalRoute: React.FC<RouterProps> = ({
+  component: Component,
+  ...rest
+}) => {
+  const auth = useRecoilValue(authState);
+
+  const checkRoute = () => {
+    return auth.isLoggedin ? <Component /> : <Redirect to="/map/signin" />;
+  };
+
+  return <Route {...rest} render={checkRoute} />;
+};
+
+export default PrivateModalRoute;

--- a/client/src/routes/PublicRoute.tsx
+++ b/client/src/routes/PublicRoute.tsx
@@ -1,0 +1,48 @@
+import React, { useEffect } from 'react';
+import { Route, RouterProps } from 'react-router-dom';
+import { useRecoilState } from 'recoil';
+import { authState } from '@stores/atoms';
+
+import { IAPIResult } from '@myTypes/Common';
+import { IUser } from '@myTypes/User';
+import { getOptions } from '@utils/common';
+
+const PublicRoute: React.FC<RouterProps> = ({
+  component: Component,
+  ...rest
+}) => {
+  const [auth, setAuth] = useRecoilState(authState);
+
+  useEffect(() => {
+    const checkUserSignIn = async () => {
+      const userInfoRes = await fetch(
+        `${process.env.REACT_APP_API_URL as string}/api/auth/info`,
+        getOptions('GET', undefined, 'same-origin'),
+      );
+      const userInfo: IAPIResult<IUser | Record<string, never>> =
+        await userInfoRes.json();
+
+      if (userInfoRes.status !== 200) {
+        return;
+      } else {
+        setAuth({
+          isLoggedin: true,
+          oauthEmail: userInfo.result.oauthEmail,
+          address: userInfo.result.address,
+          image: userInfo.result.image,
+        });
+      }
+    };
+
+    if (!auth.isLoggedin) {
+      console.log(' 요청보내기 publicRoute 효과');
+      checkUserSignIn();
+    }
+
+    console.log('useEffect publicRoute');
+  }, []);
+
+  return <Route {...rest} render={() => <Component />} />;
+};
+
+export default PublicRoute;


### PR DESCRIPTION
### 🔨 기능 설명
map에서 비로그인자에게 로딩페이지가 보이지 않도록 함
Write-review 모달에 한해서 요청이 두 번 가는 것을 한 번 가도록 함

### 📑 구현할 내용
- [x] map에서 비로그인자에게 로딩페이지가 보이지 않도록 함
- [x] Write-review 모달에 한해서 요청이 두 번 가는 것을 한 번 가도록 함

### 🚧 주의 사항
같은 fetch 요청은 취소하는 것을 고려해보기

(### 스크린 샷)
