### PR TITLE
[Refactor] 클라이언트 에러메시지 스낵바 적용 외

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -4,12 +4,12 @@ import myTheme from '@styledComponents/theme';
 import Snackbar from '@components/Snackbar';
 import PrivateRoute from '@routes/PrivateRoute';
 import ProtectRoute from '@routes/ProtectRoute';
+import PublicRoute from '@routes/PublicRoute';
 
 import React, { lazy, Suspense } from 'react';
 import { Switch, Route, Redirect } from 'react-router-dom';
 import { ThemeProvider } from 'styled-components';
 
-import LoadAnimation from '@components/Loading';
 import Header from '@components/Header';
 import { LoadingPage } from '@pages/index';
 
@@ -29,7 +29,7 @@ const App: React.FC = () => {
       <GlobalStyle />
       <ThemeProvider theme={myTheme}>
         <GlobalStore>
-          <Suspense fallback={<LoadAnimation />}>
+          <Suspense fallback={null}>
             <Snackbar />
             <Header />
             <Switch>
@@ -38,7 +38,7 @@ const App: React.FC = () => {
                 path="/"
                 component={() => <Redirect to={{ pathname: '/map' }} />}
               />
-              <Route path="/map" render={() => <MainPage />} />
+              <PublicRoute path="/map" component={MainPage} />
               <Route path="/github/callback" render={() => <LoadingPage />} />
               <ProtectRoute path="/loading" component={LoadPage} />
               <PrivateRoute path="/profile" component={ProfilePage} />
@@ -50,10 +50,10 @@ const App: React.FC = () => {
             />
             <Route path="/:back/ranking" render={() => <RankingModal />} />
             <Route path="/:back/signin" render={() => <SignInModal />} />
-            <ProtectRoute path="/:back/signup" compoent={SignUpModal} />
-            <PrivateRoute
-              path="/:back/update-address"
-              component={ProfileAddressModal}
+            <ProtectRoute path="/map/signup" component={SignUpModal} />
+            <Route
+              path="/profile/update-address"
+              render={() => <ProfileAddressModal />}
             />
           </Suspense>
         </GlobalStore>

--- a/client/src/controllers/loadController.ts
+++ b/client/src/controllers/loadController.ts
@@ -1,6 +1,7 @@
 import { IAPIResult } from '@myTypes/Common';
 import { IUser } from '@myTypes/User';
 import { getOptions } from '@utils/common';
+import { showSnackbar } from '@utils/common';
 
 const checkUserSignIn = async (setAuth, routeHistory, location) => {
   const userInfoRes = await fetch(
@@ -11,7 +12,7 @@ const checkUserSignIn = async (setAuth, routeHistory, location) => {
     await userInfoRes.json();
 
   if (userInfoRes.status !== 200) {
-    alert(userInfo.message);
+    showSnackbar(userInfo.message, true);
     /*
     2021-11-20
     문혜현

--- a/client/src/controllers/signInController.ts
+++ b/client/src/controllers/signInController.ts
@@ -1,4 +1,5 @@
 import qs from 'qs';
+import { showSnackbar } from '@utils/common';
 import { IAPIResult } from '@myTypes/Common';
 import { IUser } from '@myTypes/User';
 import { getOptions } from '@utils/common';
@@ -35,7 +36,7 @@ const isMember = (
   setAuth,
 ): void => {
   if (status != 201) {
-    alert(userInfo.message);
+    showSnackbar(userInfo.message, true);
     routeHistory('/map/signin');
     return;
   }

--- a/client/src/controllers/signUpController.ts
+++ b/client/src/controllers/signUpController.ts
@@ -1,5 +1,6 @@
 import { SetterOrUpdater } from 'recoil';
 
+import { showSnackbar } from '@utils/common';
 import { IAPIResult } from '@myTypes/Common';
 import { ISignUp } from '@myTypes/User';
 import { IMapInfo } from '@myTypes/Map';
@@ -40,7 +41,7 @@ const isSignUp = (
   routeHistory,
 ): void => {
   if (status != 200) {
-    alert(userInfo.message);
+    showSnackbar(userInfo.message, true);
     routeHistory('/map/signin');
   } else {
     setAuth({

--- a/client/src/controllers/signUpController.ts
+++ b/client/src/controllers/signUpController.ts
@@ -40,7 +40,7 @@ const isSignUp = (
   setAuth: SetterOrUpdater<IAuthInfo>,
   routeHistory,
 ): void => {
-  if (status != 200) {
+  if (status != 201) {
     showSnackbar(userInfo.message, true);
     routeHistory('/map/signin');
   } else {

--- a/client/src/modals/ReviewSubmitModal/index.tsx
+++ b/client/src/modals/ReviewSubmitModal/index.tsx
@@ -23,9 +23,10 @@ import useHistoryRouter from '@hooks/useHistoryRouter';
 
 const ReviewModal: React.FC = () => {
   const routeHistory = useHistoryRouter();
+  const auth = useRecoilValue(authState);
   const [reviewData, setReviewData] = useState<IReviewSubmit>({
-    address: useRecoilValue(authState).address,
-    oauth_email: useRecoilValue(authState).oauthEmail,
+    address: auth.address,
+    oauth_email: auth.oauthEmail,
     text: '',
     categories: {
       safety: 1,
@@ -83,7 +84,7 @@ const ReviewModal: React.FC = () => {
     <Modal>
       <TitleDiv>
         <FontAwesomeIcon icon={faMapMarkerAlt}></FontAwesomeIcon>
-        <span style={{ marginLeft: '10px' }}>{reviewData.address}</span>
+        <span style={{ marginLeft: '10px' }}>{auth.address}</span>
       </TitleDiv>
       <StarRateDiv>{RatingStars}</StarRateDiv>
       <TextAreaDiv>

--- a/client/src/routes/PrivateModalRoute.tsx
+++ b/client/src/routes/PrivateModalRoute.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Route, Redirect, RouterProps } from 'react-router-dom';
+import { useRecoilValue } from 'recoil';
+import { authState } from '@stores/atoms';
+
+const PrivateModalRoute: React.FC<RouterProps> = ({
+  component: Component,
+  ...rest
+}) => {
+  const auth = useRecoilValue(authState);
+
+  const checkRoute = () => {
+    return auth.isLoggedin ? <Component /> : <Redirect to="/map/signin" />;
+  };
+
+  return <Route {...rest} render={checkRoute} />;
+};
+
+export default PrivateModalRoute;

--- a/client/src/routes/PublicRoute.tsx
+++ b/client/src/routes/PublicRoute.tsx
@@ -1,0 +1,48 @@
+import React, { useEffect } from 'react';
+import { Route, RouterProps } from 'react-router-dom';
+import { useRecoilState } from 'recoil';
+import { authState } from '@stores/atoms';
+
+import { IAPIResult } from '@myTypes/Common';
+import { IUser } from '@myTypes/User';
+import { getOptions } from '@utils/common';
+
+const PublicRoute: React.FC<RouterProps> = ({
+  component: Component,
+  ...rest
+}) => {
+  const [auth, setAuth] = useRecoilState(authState);
+
+  useEffect(() => {
+    const checkUserSignIn = async () => {
+      const userInfoRes = await fetch(
+        `${process.env.REACT_APP_API_URL as string}/api/auth/info`,
+        getOptions('GET', undefined, 'same-origin'),
+      );
+      const userInfo: IAPIResult<IUser | Record<string, never>> =
+        await userInfoRes.json();
+
+      if (userInfoRes.status !== 200) {
+        return;
+      } else {
+        setAuth({
+          isLoggedin: true,
+          oauthEmail: userInfo.result.oauthEmail,
+          address: userInfo.result.address,
+          image: userInfo.result.image,
+        });
+      }
+    };
+
+    if (!auth.isLoggedin) {
+      console.log(' 요청보내기 publicRoute 효과');
+      checkUserSignIn();
+    }
+
+    console.log('useEffect publicRoute');
+  }, []);
+
+  return <Route {...rest} render={() => <Component />} />;
+};
+
+export default PublicRoute;

--- a/server/src/apis/authController.ts
+++ b/server/src/apis/authController.ts
@@ -76,7 +76,7 @@ router.post('/signin', (async (
         image: oauthInfo.image,
       };
 
-      res.json(makeApiResponse(userInfo, '회원이 아닙니다.'));
+      res.status(201).json(makeApiResponse(userInfo, '회원이 아닙니다.'));
     }
   } catch (error) {
     const err = error as Error;
@@ -111,7 +111,7 @@ router.post('/signup', (async (
       getCookieOption(Number(config.jwt_cookie_expire)),
     );
 
-    res.status(200).json(
+    res.status(201).json(
       makeApiResponse(
         {
           address: address,


### PR DESCRIPTION
### 🔨 기능 설명
API 응답이 실패했을 때 Snackbar로 메시지 띄우기 (polygon, rates, mapController)
fetch에 getOptions() 유틸리티 함수 적용
중복 함수 제거 및 리팩토링 

### 📑 구현할 내용
- [x] `fetch` 실패시 (status !== 2XX) 스낵바를 이용한 에러 핸들링
- [x] `fetch`에 `getOptions()` 유틸리티 함수 적용

### 🚧 주의 사항
기능을 구현할 때 유의깊게 살펴볼 사항

(### 스크린 샷)
