### PR TITLE
[Fix] Sidebar Review 관련 버그 해소

### DIFF
--- a/client/src/components/Header/index.tsx
+++ b/client/src/components/Header/index.tsx
@@ -106,7 +106,14 @@ const Header: React.FC = () => {
               <>
                 <LogoutBtn onClick={onLogoutClick}>로그아웃</LogoutBtn>
                 <UserProfile onClick={onProfileClick}>
-                  <ProfileImage src={auth.image} alt="프로필사진" />
+                  <ProfileImage
+                    src={
+                      auth.image.length > 0
+                        ? auth.image
+                        : process.env.REACT_APP_IMAGE_DEFAULT_USER
+                    }
+                    alt="프로필사진"
+                  />
                 </UserProfile>
               </>
             ) : (

--- a/client/src/components/Map/index.tsx
+++ b/client/src/components/Map/index.tsx
@@ -59,6 +59,7 @@ const MapComponent: React.FC<IProps> = ({
   updateSidebarContents,
 }) => {
   const mapWrapper = useRef<HTMLDivElement | null>(null);
+  const currentAddress = useRef<string>('');
   const [map, setMap] = useState<kakao.maps.Map | null>(null);
   const [range, setRange] = useState(DEFAULT_RANGE);
 
@@ -151,6 +152,8 @@ const MapComponent: React.FC<IProps> = ({
 
     const wrapper = mapWrapper.current;
     const onClick = async (rateData: IMapInfo) => {
+      if (currentAddress.current === rateData.address) return;
+      currentAddress.current = rateData.address;
       const sidebarContents: IAPIResult<IReviewContent[]> =
         await fetchContentData(rateData.address, 'review');
 
@@ -198,6 +201,8 @@ const MapComponent: React.FC<IProps> = ({
 
         const markerEl = matchingMarker.getContent() as HTMLElement;
         const sidebarRate = JSON.parse(markerEl.dataset.rateData as string);
+        if (currentAddress.current === sidebarRate.address) return;
+        currentAddress.current = sidebarRate.address;
 
         const sidebarContents: IAPIResult<IReviewContent[]> =
           await fetchContentData(polygon.address, 'review');

--- a/client/src/components/Map/index.tsx
+++ b/client/src/components/Map/index.tsx
@@ -48,6 +48,7 @@ const DEFAULT_RANGE: IRange = {
 interface IProps {
   openSidebar: () => void;
   closeSidebar: () => void;
+  currentAddress: React.MutableRefObject<string>;
   updateSidebarRate: (rateData: IMapInfo) => void;
   updateSidebarContents: (contentsData: IReviewContent[]) => void;
 }
@@ -55,11 +56,11 @@ interface IProps {
 const MapComponent: React.FC<IProps> = ({
   openSidebar,
   closeSidebar,
+  currentAddress,
   updateSidebarRate,
   updateSidebarContents,
 }) => {
   const mapWrapper = useRef<HTMLDivElement | null>(null);
-  const currentAddress = useRef<string>('');
   const [map, setMap] = useState<kakao.maps.Map | null>(null);
   const [range, setRange] = useState(DEFAULT_RANGE);
 

--- a/client/src/components/Profile/index.tsx
+++ b/client/src/components/Profile/index.tsx
@@ -51,6 +51,7 @@ const Profile: React.FC = () => {
                 ? auth.image
                 : process.env.REACT_APP_IMAGE_DEFAULT_USER
             }
+            alt="프로필사진"
           />
           <div>
             <input

--- a/client/src/components/Searchbar/index.tsx
+++ b/client/src/components/Searchbar/index.tsx
@@ -92,7 +92,7 @@ const Searchbar: React.FC<SearchbarProps> = ({
   return (
     <div style={{ position: 'relative' }}>
       <SearchbarWrapper>
-        <SearchbarInput onChange={onInputChange} ref={inputTagRef} />
+        <SearchbarInput onChange={onInputChange} ref={inputTagRef} autoFocus />
         <SearchbarButton>
           <SearchImg />
         </SearchbarButton>

--- a/client/src/controllers/profileController.ts
+++ b/client/src/controllers/profileController.ts
@@ -55,22 +55,11 @@ const updateAddress =
   (auth: IAuthInfo, setAuth: SetterOrUpdater<IAuthInfo>) =>
   async (mapInfo: IMapInfo) => {
     const response = await fetch(
-<<<<<<< HEAD
       `${process.env.REACT_APP_API_URL}/api/user/profile/address`,
-      {
-        ...getOptions('PATCH', {
-          oauth_email: auth.oauthEmail,
-          address: mapInfo.address,
-        }),
-        headers: { 'Content-type': 'application/json' },
-      },
-=======
-      `${process.env.REACT_APP_API_URL}/api/user/profile-address`,
       getOptions('PATCH', {
         oauth_email: auth.oauthEmail,
         address: mapInfo.address,
       }),
->>>>>>> Fix: #223 - 프로필 이미지 업데이트, 삭제 버그 수정
     );
     const result = await response.json();
     if (response.status === 200) {

--- a/client/src/controllers/profileController.ts
+++ b/client/src/controllers/profileController.ts
@@ -17,7 +17,7 @@ const uploadImage = async (
   formData.append('image', auth.image);
   const response = await fetch(
     `${process.env.REACT_APP_API_URL}/api/user/profile/image`,
-    getOptions('PATCH', formData, 'same-origin'),
+    getOptions('PATCH', formData, 'same-origin', false, null),
   );
   const result = await response.json();
   if (response.status === 200) {
@@ -56,13 +56,10 @@ const updateAddress =
   async (mapInfo: IMapInfo) => {
     const response = await fetch(
       `${process.env.REACT_APP_API_URL}/api/user/profile/address`,
-      {
-        ...getOptions('PATCH', {
-          oauth_email: auth.oauthEmail,
-          address: mapInfo.address,
-        }),
-        headers: { 'Content-type': 'application/json' },
-      },
+      getOptions('PATCH', {
+        oauth_email: auth.oauthEmail,
+        address: mapInfo.address,
+      }),
     );
     const result = await response.json();
     if (response.status === 200) {

--- a/client/src/controllers/profileController.ts
+++ b/client/src/controllers/profileController.ts
@@ -17,7 +17,7 @@ const uploadImage = async (
   formData.append('image', auth.image);
   const response = await fetch(
     `${process.env.REACT_APP_API_URL}/api/user/profile/image`,
-    getOptions('PATCH', formData, 'same-origin'),
+    getOptions('PATCH', formData, 'same-origin', false, null),
   );
   const result = await response.json();
   if (response.status === 200) {
@@ -55,6 +55,7 @@ const updateAddress =
   (auth: IAuthInfo, setAuth: SetterOrUpdater<IAuthInfo>) =>
   async (mapInfo: IMapInfo) => {
     const response = await fetch(
+<<<<<<< HEAD
       `${process.env.REACT_APP_API_URL}/api/user/profile/address`,
       {
         ...getOptions('PATCH', {
@@ -63,6 +64,13 @@ const updateAddress =
         }),
         headers: { 'Content-type': 'application/json' },
       },
+=======
+      `${process.env.REACT_APP_API_URL}/api/user/profile-address`,
+      getOptions('PATCH', {
+        oauth_email: auth.oauthEmail,
+        address: mapInfo.address,
+      }),
+>>>>>>> Fix: #223 - 프로필 이미지 업데이트, 삭제 버그 수정
     );
     const result = await response.json();
     if (response.status === 200) {

--- a/client/src/modals/ProfileAddressModal/index.tsx
+++ b/client/src/modals/ProfileAddressModal/index.tsx
@@ -7,16 +7,20 @@ import useHistoryRouter from '@hooks/useHistoryRouter';
 import React, { useCallback } from 'react';
 import { useLocation } from 'react-router-dom';
 import { getPrevPath } from '@utils/common';
+import { IMapInfo } from '@myTypes/Map';
 
 const ProfileAddressModal: React.FC = () => {
   const routeHistory = useHistoryRouter();
   const { pathname } = useLocation();
   const [auth, setAuth] = useRecoilState(authState);
 
-  const onSubmitHandler = useCallback(() => {
-    updateAddress(auth, setAuth);
-    routeHistory(getPrevPath(pathname), {});
-  }, [auth, setAuth, routeHistory, pathname]);
+  const onSubmitHandler = useCallback(
+    (mapInfo: IMapInfo) => {
+      updateAddress(auth, setAuth)(mapInfo);
+      routeHistory(getPrevPath(pathname), {});
+    },
+    [auth, setAuth, routeHistory, pathname],
+  );
 
   const onCancelHandler = useCallback(
     () => routeHistory(getPrevPath(pathname)),

--- a/client/src/pages/MainPage.tsx
+++ b/client/src/pages/MainPage.tsx
@@ -1,6 +1,6 @@
 import MapComponent from '@components/Map/index';
 
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useRef } from 'react';
 import styled from 'styled-components';
 import Sidebar from '@components/Sidebar';
 
@@ -37,6 +37,7 @@ const DEFAULT_RATE_DATA: IMapInfo = {
 };
 
 const MainPage: React.FC = () => {
+  const currentAddress = useRef<string>('');
   const [sidebar, setSidebar] = useState<boolean>(false);
   const [sidebarAnimation, setSidebarAnimation] = useState<string>('close');
   const [sidebarRate, setSidebarRate] = useState<IMapInfo>(DEFAULT_RATE_DATA);
@@ -48,6 +49,7 @@ const MainPage: React.FC = () => {
   }, []);
 
   const closeSidebar = useCallback(() => {
+    currentAddress.current = '';
     setSidebarAnimation('close');
     setTimeout(() => setSidebar(false), 500);
   }, []);
@@ -69,6 +71,7 @@ const MainPage: React.FC = () => {
         <MapComponent
           openSidebar={openSidebar}
           closeSidebar={closeSidebar}
+          currentAddress={currentAddress}
           updateSidebarRate={updateSidebarRate}
           updateSidebarContents={updateSidebarContents}
         ></MapComponent>

--- a/client/src/utils/common.ts
+++ b/client/src/utils/common.ts
@@ -73,16 +73,19 @@ const getOptions = <T>(
   fetchMethod: 'GET' | 'POST' | 'PATCH' | 'DELETE' | 'UPDATE',
   data: T,
   credential: 'omit' | 'same-origin' | 'include' = 'omit',
+  isStringify = true,
+  contentType: string | null | undefined = 'application/json',
 ): RequestInit => {
-  return {
+  const options: RequestInit = {
     method: fetchMethod,
     mode: 'cors',
     credentials: credential,
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify(data),
+    body: (isStringify ? JSON.stringify(data) : data) as BodyInit,
   };
+  if (contentType) {
+    options.headers = { 'Content-Type': contentType };
+  }
+  return options;
 };
 
 const fetcher = async <T>(

--- a/server/src/models/Review.ts
+++ b/server/src/models/Review.ts
@@ -29,7 +29,7 @@ const reviewSchema = new Schema<Review>({
   },
   text: { type: String },
   oauth_email: { type: String, required: true, index: true },
-  createdAt: { type: Date, required: true, default: new Date() },
+  createdAt: { type: Date, required: true, default: () => new Date() },
 });
 
 const ReviewModel = model<Review>('Review', reviewSchema);


### PR DESCRIPTION
### 🔨 작업 내용 설명
- Sidebar Review 관련 버그 해소

### 📑 구현한 내용
- Sidebar 열려 있는 상태에서 같은 지역의 Polygon, Marker 클릭 시 Contents 내용이 초기화되는 에러 발생
  -> 해당 에러는 Map.tsx에서 기존 선택된 Address를 useRef로 관리하고 해당 값이 변경되지 않은 경우 fetch 및 update를 방지함으로써 해소

- Sidebar 열려 있는 상태에서 메뉴를 번갈아 클릭 시 Contents 정보가 이상하게 렌더링 되는 에러 발생
  -> 해당 에러는 ReviewContent.tsx의 Intersection Observer, fetchData 함수가 자주 re-rendering 되면서 복수의 fetch를 보냄으로 인해 발생하는 문제로 추정되어, 기존 useState로 관리하는 항목을 일부 useRef로 변경(pageNumber, hasMore)하고 Intersection Observer를 진행하는 함수의 dependency를 변경하여 해소

- Sidebar 열고 닫은 후, 동일 Address 클릭 시 Sidebar 열리지 않는 이슈 해소
  -> useRef로 현재 address를 Mainpage에서 관리하여 Sidebar 열릴 때, 닫힐 때에 해당 값을 변경시켜서 해소

- Sidebar의 Review 업로드된 시간이 정상적으로 되지 않는 이슈 해소
  -> Review Modal에서 new Date() 부분을 화살표 함수 방식으로 변경

### 🚧 주의 사항
- 상태 관리의 어려움, useRef / useState를 적절하게 사용하는 것이 매우 어렵다고 느낌

[### 스크린 샷]
![Animation](https://user-images.githubusercontent.com/31230442/144269283-7f7d0f91-c7fe-403e-a06b-5bbad04f6656.gif)

close #226 
