### PR TITLE
[Fix] dropdown 화면 넘침 수정

### DIFF
--- a/client/src/components/Searchbar/index.tsx
+++ b/client/src/components/Searchbar/index.tsx
@@ -69,10 +69,12 @@ const Searchbar: React.FC<SearchbarProps> = ({
   }, [valueState]);
 
   useEffect(() => {
-    if (dropdownTagRef.current !== null) {
-      setDropdownTop(getTop(dropdownTagRef.current));
+    if (inputTagRef.current !== null) {
+      setDropdownTop(
+        getTop(inputTagRef.current) + inputTagRef.current.offsetHeight,
+      );
     }
-  }, [dropdownTagRef.current]);
+  }, []);
 
   useEffect(() => {
     const updateFocus = (e) => {


### PR DESCRIPTION
### 🔨 작업 내용 설명
드롭다운 초기 화면 넘침 수정

### 📑 구현한 내용
- dropdown의 max-height을 계산할 때, input을 기준으로 하도록 수정

close #253 
